### PR TITLE
docs(icm): integrate Sprite Foundry context safely

### DIFF
--- a/DEV_JOURNAL.md
+++ b/DEV_JOURNAL.md
@@ -137,6 +137,15 @@ Append entries newest-first immediately below this heading when practical:
 
 ---
 
+### 2026-08-09 15:58 ET — ChatGPT — audit and integrate current repo work
+- **Read/inspected:** current `main`, recent commits, GitHub Actions, open/diverged branches, production-readiness convergence work, Devin audit/refactor branches, AI-provider branch, CSS/UI branches, old Mac branches, and the Sprite Foundry ICM branch.
+- **Changed:** restored the blocking CI verification path on `main` through PR #29; added ESLint flat config and actionable Stylelint annotations; repaired undefined AI fallback and host-animation sound wiring; normalized token CSS; integrated the Sprite Foundry ICM corpus onto a fresh branch and registered it as `PRESSURE_TEST` rather than blindly inheriting `ACTIVE` status.
+- **Evidence/tests:** PR #29 passed JS lint, CSS lint, Jest tests, Vite build, accessibility step, and artifact upload; squash commit `0e39a9a` then passed the same full CI pipeline on `main`. GitHub Actions is the authoritative execution environment for this pass because the local sandbox could not resolve github.com for a clone.
+- **Decisions:** do not wholesale-merge heavily diverged branches. `cleanup/production-readiness`, Devin refactor work, `review/css-ui-fixes`, Mac branches, and the old AI integration branch are salvage quarries/oracles until individual behaviors are re-proved against current `main`. `fix/css-audit-fixes` is already fully behind main. Sprite Foundry is valuable context, but factory implementation remains gated by the canonical runtime/deterministic-spine work.
+- **Unresolved:** current CI proves lint/tests/build, not a real blocking browser playthrough; GitHub Actions also warns that checkout/setup-node v4 target deprecated Node 20 runtimes. Several historical branches contain useful features that still need capability-by-capability archaeology rather than merge-by-branch thinking.
+- **Next lead domino:** add a blocking deterministic browser smoke path that boots the production build and exercises one game spine; then use that proof harness to port the smallest Stage/runtime slice and selectively mine production-readiness/Jeopardish goodness.
+- **Refs:** `main@0e39a9a`, PR #29, `integrate/sprite-foundry-context`, `ICM/projects/sprite-foundry/*`.
+
 ### 2026-08-08 — ChatGPT — mine design cypher into ICM
 - **Read/inspected:** full active conversation context; existing glossary/journal; current repo root/docs; Zeke concept boards and real-life playground reference supplied in conversation.
 - **Changed:** established `ICM/` as the Immortal Context Map and scaffolded durable project records for uINVERSE, You in Verse, Stool Samples, ALgoRHYTHM B, Brazillionaire, Zeke Discovers, Archimedes, Excavation Station, and the self-building Asset Library.

--- a/ICM/README.md
+++ b/ICM/README.md
@@ -32,6 +32,7 @@ Statuses: `SEED`, `PRESSURE_TEST`, `PROTOTYPE`, `ACTIVE`, `CANONICAL`, `ARCHIVED
 | `archimedes` | SEED | Maltese protagonist/platformer and recurring cross-world character |
 | `excavation-station` | PRESSURE_TEST | project archaeology and recovery workflow |
 | `asset-library` | PRESSURE_TEST | first-class generated/imported asset registry and provenance pipeline |
+| `sprite-foundry` | PRESSURE_TEST | reproducible manifest-backed asset production machine shop |
 
 ## Cross-project architecture hypothesis
 

--- a/ICM/projects/sprite-foundry/ASSETS.md
+++ b/ICM/projects/sprite-foundry/ASSETS.md
@@ -1,0 +1,76 @@
+# Sprite Foundry — Assets
+
+## Canonical character targets
+
+### Alex
+- Type: human / creator avatar
+- Source requirement: user-provided visual reference before likeness generation
+- Initial outputs: portrait, turnaround, idle, talk, point, celebrate, host/cameo variants
+
+### Archie / Archimedes Beckerman
+- Type: small shaggy white dog; Maltese with Chihuahua and Pomeranian mix
+- Canonical traits: floppy ears/hair, expressive dark eyes, black button nose, compact body, enormous curled plume tail, subtly suspicious expression
+- Personality in motion: screw loose, sudden inappropriate confidence, odd ear behavior, invisible-phenomena reactions, manic victory poses
+- Initial outputs: turnaround, idle, walk, run, jump, fall, land, sniff, suspicious stare, interact, celebrate
+
+### Christopher Walken host archetype
+- Type: guest-host character pack
+- Initial outputs: turnaround, idle, clue-read, pause/ponder, gesture, reaction, celebrate
+
+### Leslie Nielsen host archetype
+- Type: guest-host character pack
+- Initial outputs: turnaround, idle, deadpan read, confused beat, absurd reaction, gesture, celebrate
+
+## Shared studio bird cast
+Keep these modular and reusable across Jeopardish, jeoPARODY, Archimedes Adventures, and Cinematic Studio scenes:
+- Gullian: seagull cameraman / autonomous camera operator
+- Rickigeon: chaotic pigeon problem-solver
+- Randers Pelicandy: pelican with absurd pouch inventory
+- Jim LaHeron: authority/supervisor heron
+- J-Rook: corvid performer / self-appointed hype-man
+
+## Asset unit
+Every production artifact should carry at minimum:
+
+```json
+{
+  "assetId": "character.state.variant.v001",
+  "project": "shared",
+  "character": "archie",
+  "type": "animation",
+  "sources": [],
+  "styleGuide": "jeopardish-pixel-shared",
+  "frameSize": [64, 64],
+  "anchors": {},
+  "attachments": [],
+  "palette": "default",
+  "version": 1,
+  "status": "candidate"
+}
+```
+
+## Library slots
+
+```text
+assets/library/
+  characters/<slug>/
+    source/
+    masters/
+    cutouts/
+    body-parts/
+    expressions/
+    poses/
+    sprites/
+    animations/
+    costumes/
+    accessories/
+    palettes/
+    manifests/
+  shared/
+    props/
+    effects/
+    cameras/
+    palettes/
+```
+
+Preserve original sources and generated provenance. Derived assets should be reproducible whenever practical.

--- a/ICM/projects/sprite-foundry/BACKLOG.md
+++ b/ICM/projects/sprite-foundry/BACKLOG.md
@@ -1,0 +1,28 @@
+# Sprite Foundry — Backlog
+
+## Highest-leverage next machines
+1. Real transparent-background cutout worker with mask preservation.
+2. Alpha/edge cleanup worker with halo detection.
+3. Registration worker that normalizes baselines, pivots, sockets, and canonical canvas sizes.
+4. Contact-sheet / sprite-sheet compositor for 48/64/96px targets.
+5. Manifest validator and deterministic asset naming.
+6. Viewport matrix capture for responsive visual regression.
+7. Animation strip builder with per-frame timing/events.
+8. Asset dependency graph and selective regeneration.
+
+## Character batches
+- Archie reference-photo ingestion and first canonical master sheet.
+- Alex likeness pack after user visual reference is supplied.
+- Christopher Walken guest-host sheet.
+- Leslie Nielsen guest-host sheet.
+- Gullian, Rickigeon, Randers Pelicandy, Jim LaHeron, J-Rook studio crew sheets.
+
+## Engine integration
+- `assets.get(query)` registry lookup instead of hard-coded paths.
+- cache/prefetch service-worker layer visualized through The Mailroom.
+- scenes declare asset dependencies through manifests.
+- Cinematic Studio can request character pose/expression/camera assets through the same registry.
+- games remain composable components consuming shared factories rather than copying implementations.
+
+## Dev-debt rule
+Every repeated manual correction should be evaluated for conversion into a validator, transform, reusable primitive, test, or machine. Bugs should leave behind stronger infrastructure whenever practical.

--- a/ICM/projects/sprite-foundry/README.md
+++ b/ICM/projects/sprite-foundry/README.md
@@ -1,0 +1,43 @@
+# Sprite Foundry
+
+Status: PRESSURE_TEST
+
+## Promise
+Build a reusable asset-production machine shop for jeoPARODY and the shared game engine. Raw source images enter once; the system cuts out, cleans, normalizes, separates, registers, poses, pixelizes, animates, validates, catalogs, and routes production-ready assets into a shared library.
+
+## Lead domino
+Prove one deterministic, reproducible vertical slice from source reference to validated manifest-backed game asset before expanding the factory surface. Candidate character targets are Alex, Archie / Archimedes Beckerman, Christopher Walken, and Leslie Nielsen, but the first proof should use the smallest legally and technically clean specimen available.
+
+## Machine contract
+Every machine accepts a typed asset manifest and emits files plus updated metadata. Machines should be composable, branchable, replayable, cacheable, and provenance-aware.
+
+```text
+SOURCE INTAKE
+  -> CUTOUT
+  -> ALPHA / EDGE CLEANUP
+  -> SCALE + REGISTRATION
+  -> BODY-PART SEPARATION
+  -> POSE GENERATION
+  -> PIXEL RASTERIZATION
+  -> ANIMATION LOOM
+  -> ACCESSORY / VARIANT COMBINER
+  -> QC
+  -> MANIFEST STAMPER
+  -> MAILROOM / ASSET LIBRARY
+```
+
+## Self-building rule
+Whenever a recurring production problem is solved, prefer turning the solution into a reusable machine, function, test, validator, editor, graph operation, or factory. The engine should progressively acquire better hands and a larger MacGyver/Batman toolbelt.
+
+## Shared-engine role
+A complete game is itself a composable component assembled from reusable scenes, maps, actors, graphs, factories, cinematics, assets, systems, and tools. Sprite Foundry is one production subsystem inside that larger recursive engine.
+
+## Scope guardrail
+This ICM record preserves the factory architecture. It does not authorize a universal asset platform before the current jeoPARODY runtime and deterministic game spine are healthy. Promote this project beyond `PRESSURE_TEST` only after the first end-to-end asset specimen is reproducible and consumed by the canonical runtime.
+
+## Do not
+- create one-off character exports when a reusable machine would solve the class of problem;
+- destroy original sources;
+- flatten provenance;
+- bake costumes/accessories into every sprite if they can remain modular;
+- silently diverge from the shared Jeopardish handcrafted pixel-art style guide.

--- a/ICM/projects/sprite-foundry/STAGE.md
+++ b/ICM/projects/sprite-foundry/STAGE.md
@@ -1,0 +1,18 @@
+# Sprite Foundry — Stage
+
+## Projection: Machine Shop
+A visual developer-facing factory floor where typed assets move through connected machines. Useful for understanding pipeline state, dependencies, failures, and provenance.
+
+## Projection: Character Workbench
+Select a character and inspect source references, master cutouts, body parts, sockets, expressions, poses, sprites, animations, accessories, and variants side by side.
+
+## Projection: Mailroom
+Requests fly between components and library slots. Cache hits, misses, prefetches, failures, and routing can be represented physically for debugging without changing the underlying semantics.
+
+## Projection: QA Lab
+A deliberately chaotic device wall runs the game across resolutions, pixel ratios, orientations, input modes, and stress conditions. Every failure produces a capture bundle and a routable issue; every useful accident can be promoted into the idea backlog.
+
+## Art direction
+All character projections should inherit the established shared Jeopardish language: premium handcrafted pixel art, strong readable silhouettes, expressive caricature, controlled pixel clusters, modular wardrobe/props/effects, and personality visible in pose and motion.
+
+These projections are interfaces over the same semantic asset graph. The world metaphor should clarify the architecture rather than become a second architecture that must be maintained separately.

--- a/ICM/projects/sprite-foundry/WORLD.md
+++ b/ICM/projects/sprite-foundry/WORLD.md
@@ -1,0 +1,29 @@
+# Sprite Foundry — World
+
+The Foundry is both architecture and a legible in-world metaphor for the engine's production infrastructure.
+
+## Places / machines
+- Intake Hopper: registers source material and provenance.
+- Cutout Engine: produces transparent subject/component cutouts and masks.
+- Edge Forge: repairs halos, alpha damage, and contours.
+- Registration Jig: normalizes scale, baseline, pivots, sockets, facing, and canvas.
+- Body-Part Separator: emits modular head/body/limb/tail/prop layers.
+- Pose Mill: creates named canonical poses.
+- Pixel Rasterizer: enforces the handcrafted Jeopardish pixel-art grammar.
+- Animation Loom: builds frame sequences, timing, events, and transitions.
+- Accessory Press: creates wearable/held/effect modules.
+- Variant Combiner: assembles compatible modular combinations.
+- QC Inspector: validates alpha, dimensions, anchors, palettes, clipping, and continuity.
+- Manifest Stamper: records identity, lineage, state, and compatibility.
+- The Mailroom: routes/cache-serves assets to requesting components; its service-worker visualization may use a frantic old-school mailroom-worker archetype slinging requests into cubbies.
+- Responsive Torture Rack: captures scenes across viewport/device matrices and routes failures into reusable fixes/tests.
+
+## Actors
+- Characters and hosts are asset families rather than monolithic images.
+- Gullian can serve as the diegetic Cinematic Studio camera operator, physically embodying follow/lead/chase/orbit/reveal camera behavior.
+- QA/playtest agents deliberately stress device sizes, inputs, timing, network states, cinematics, and layout boundaries, preserving both bugs and accidental discoveries.
+
+## Semantic events
+`source.registered`, `cutout.created`, `anchor.assigned`, `part.extracted`, `pose.created`, `sprite.rasterized`, `animation.built`, `qc.failed`, `qc.passed`, `asset.cataloged`, `asset.requested`, `asset.served`.
+
+These events should eventually form a graph so every derived asset can answer: what made me, what do I depend on, where am I used, and what should regenerate if my source changes?


### PR DESCRIPTION
## Why
The Sprite Foundry branch contains valuable durable architecture but diverged from current main. Merging it wholesale would import branch history rather than the useful context.

## Integration
- port the five Sprite Foundry ICM records onto fresh current-main history
- register `sprite-foundry` in the ICM registry
- deliberately classify it as `PRESSURE_TEST`, not `ACTIVE`, until an end-to-end manifest-backed asset is reproducible and consumed by canonical runtime
- record the repo audit, CI recovery, branch classifications, and next lead domino in `DEV_JOURNAL.md`

## Guardrail
This preserves the machine-shop idea without allowing it to outrun the immediate runtime goal: production boot + deterministic browser game spine.