### PR TITLE
Feat: deepen the Needle Drop game loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,15 @@ jobs:
           BASE_URL: http://127.0.0.1:4173
         run: npm run runtime:check
 
+      - name: Needle Drop browser runtime check
+        env:
+          BASE_URL: http://127.0.0.1:4173
+        run: npm run needle-drop:runtime-check
+
       - name: A11y Audit (axe-core)
-        run: npx axe http://127.0.0.1:4173/ --chromium --exit 0 --timeout 60000 --save ./axe-report.json || true
+        run: |
+          npx axe http://127.0.0.1:4173/ --chromium --exit 0 --timeout 60000 --save ./axe-report.json || true
+          npx axe 'http://127.0.0.1:4173/needle-drop.html?players=4' --chromium --exit 0 --timeout 60000 --save ./axe-needle-drop-report.json || true
 
       - name: Upload runtime evidence
         if: always()
@@ -70,7 +77,9 @@ jobs:
           name: runtime-check-evidence
           path: |
             screenshots/runtime-check
+            screenshots/needle-drop-runtime
             axe-report.json
+            axe-needle-drop-report.json
             /tmp/jeoparody-preview.log
           if-no-files-found: ignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ temp/
 # Testing
 /coverage
 /.nyc_output
+/screenshots/
 
 # Misc
 *.tgz

--- a/docs/NEEDLE_DROP_ARCHITECTURE.md
+++ b/docs/NEEDLE_DROP_ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Needle Drop — MVP architecture
+# Needle Drop — proving architecture
 
 **Lifecycle:** Proving  
 **Concept ID:** `game-mode.needle-drop`  
@@ -11,8 +11,10 @@ Needle Drop is a composable JeoPARODY music-game mode. The proving build asks wh
 1. **One truth kernel.** `core/round.js` owns phases, scoring, authored answer acceptance, and transitions. It has no DOM, audio, timer, or storage dependency.
 2. **Content is executable data.** `core/content.js` provides a versioned, immutable, rights-gated episode manifest and validator. Original Web Audio sequences stand in for future cleared assets.
 3. **Audio is an adapter.** `AudioRuntime` dispatches to the procedural synth or a decoded-buffer implementation that verifies SHA-256 integrity before decoding and schedules exact offset/duration windows.
-4. **Presentation consumes state.** `main.js` dispatches actions and emits `needle-drop:*` semantic events for future host, camera, analytics, haptics, and multiplayer directors.
+4. **Presentation consumes state.** `presentation/markup.js` turns serializable truth into escaped HTML. `main.js` stays the composition root, dispatches actions, manages focus/audio, and emits `needle-drop:*` semantic events for future host, camera, analytics, haptics, and multiplayer directors.
 5. **The build stays independently playable.** `needle-drop.html` is a separate Vite entry point while the mode proves itself.
+6. **A miss is gameplay, not a funeral.** Wrong solo answers unlock the next reveal; wrong party answers lock only that player for the current clip and open a steal. The reducer adjudicates every lockout.
+7. **Persistence is optional.** `ProfileStore` keeps a solo personal best, but storage failure never blocks a round. Scores are not national secrets, despite what the scoreboard implies.
 
 ```text
 needle-drop.html
@@ -22,7 +24,9 @@ needle-drop.html
       ├─ services/audioRuntime.js implementation router
       ├─ services/synthAudio.js procedural demo adapter
       ├─ services/decodedBufferAudio.js integrity-checked asset adapter
+      ├─ presentation/markup.js  escaped state-to-view boundary
       ├─ presentation/Waveform.js
+      ├─ services/profileStore.js optional local personal best
       └─ styles.css
 ```
 
@@ -30,14 +34,19 @@ needle-drop.html
 
 ```js
 {
-  phase, episodeId, clueIndex, revealIndex,
+  phase, episodeId, clueIndex, revealIndex, listenedRevealIndex,
   score, streak, correct,
-  attempts: [{ clueId, answer, accepted, revealIndex, points }],
+  players: [{ id, score, streak, correct, attempts }],
+  activePlayerId, blockedPlayerIds,
+  attempts: [{ clueId, playerId, answer, accepted, revealIndex, points }],
+  lastAttempt, audioError,
   result
 }
 ```
 
-Actions are serializable: `PLAY_REVEAL`, `REVEAL_FINISHED`, `MORE_AUDIO`, `SUBMIT_ANSWER`, `NEXT_CLUE`, and `RESTART`. Episode version plus action log provides deterministic truth replay.
+Actions are serializable: `PLAY_REVEAL`, `REVEAL_FINISHED`, `AUDIO_FAILED`, `BUZZ`, `MORE_AUDIO`, `SUBMIT_ANSWER`, `PASS`, `GIVE_UP`, `NEXT_CLUE`, and `RESTART`. Episode version plus action log provides deterministic truth replay.
+
+The important invariant is that `SUBMIT_ANSWER` and `MORE_AUDIO` are rejected until the current reveal has completed. In party mode, `blockedPlayerIds` resets when the room purchases a longer reveal. This gives every reveal its own fair buzz window without requiring timers or network clocks in the truth kernel.
 
 ## Production content extension
 

--- a/docs/NEEDLE_DROP_SECOND_PASS_2026-08-22.md
+++ b/docs/NEEDLE_DROP_SECOND_PASS_2026-08-22.md
@@ -1,0 +1,129 @@
+# Needle Drop — second-pass product and engineering plan
+
+**Date:** 2026-08-22  
+**Release target:** proving build 1.2  
+**North-star question:** Does one tiny clip create enough tension, recognition, argument, and laughter that the room demands another?
+
+## Executive read
+
+The first proving build established a strong visual identity, an independently deployable entry point, deterministic scoring, original procedural music, a licensed-asset seam, and one-to-four-player couch controls. The second-pass audit found that the surface looked more finished than the game loop behaved. This is a delightful problem. It means the patient has excellent shoes.
+
+The immediate priority is not adding accounts, AI hosts, a marketplace, or an animated record executive who asks for your password. It is making the listen–guess–steal loop fair, legible, replayable, and resilient enough for blind playtests.
+
+## Audit findings
+
+### Critical gameplay
+
+1. Solo answers were accepted before a clip was heard.
+2. “Buy more audio” could lower the value before the current reveal was played.
+3. Party instructions advertised buzzing while the reducer still rejected buzzes.
+4. A wrong party answer ended the clue instead of opening a steal.
+5. Buzz number keys could fire while somebody typed a numeric answer and rerender the form.
+6. The finale reported a room total but did not crown a party winner.
+
+### Experience and accessibility
+
+1. There was no concise explanation of the reveal ladder, replays, or buzz ownership.
+2. State changes relied heavily on disabled controls and color, with no host-style live status.
+3. Result and finale transitions did not deliberately move focus.
+4. Canvas semantics described the waveform but did not expose it as an image.
+5. Player-count navigation omitted three-player rooms and did not mark the active selection.
+
+### Reliability and retention
+
+1. A rejected audio promise could strand the state in `listening` forever.
+2. There was no safe cancellation token around asynchronous playback completion.
+3. A completed solo run had no personal-best loop.
+4. Four clues were enough to prove boot, but not enough to judge session rhythm.
+5. The composition root owned too much view markup, making further iteration needlessly risky.
+
+## Now — implemented in proving build 1.2
+
+### Truth kernel
+
+- Require a completed reveal before any answer or value reduction.
+- Track `listenedRevealIndex`, active player, reveal-scoped lockouts, last attempt, and audio errors.
+- Keep a wrong solo guess alive: the player can buy a longer reveal and try again.
+- Keep a wrong party guess alive: that player locks out and everyone else can steal.
+- Reset lockouts only when the room buys a longer reveal.
+- Resolve a miss after a room concession or after everyone misses the final reveal.
+- Score streak bonuses per player instead of pretending the room shares one nervous system.
+- Rank players deterministically by score, correct answers, then seat order.
+
+### Player experience
+
+- Add compact in-page rules and an explicit host call for every phase.
+- Add three-player mode and active-state semantics to player-count controls.
+- Mark active and locked players with text as well as color.
+- Add free replay, progressive reveal, and “reveal answer” as distinct choices.
+- Add a party podium and solo personal best at the finale.
+- Double the demo crate from four to eight original procedural clues.
+- Add liner-note jokes to make the source-to-flip reveal feel like a payoff, not a database row wearing a tie.
+
+### Reliability, modularity, and access
+
+- Catch audio failure and return to a retryable ready state.
+- Tokenize playback completion so stale async work cannot advance a newer round.
+- Make synth cancellation resolve outstanding playback promises cleanly.
+- Ignore buzz shortcuts while the user is typing or using modifier keys.
+- Move all escaped markup into a dedicated presentation module.
+- Add optional, failure-tolerant local profile storage.
+- Add live status regions, focus management, visible focus, waveform image semantics, reduced-motion handling, and responsive party layouts.
+- Expand reducer, party, storage, presentation, content, rights, and adapter tests.
+
+## Next — validate before building
+
+These are the next candidates, ordered by learning value rather than how impressive they sound in a pitch deck.
+
+1. **Blind room playtest instrumentation.** Record only anonymous semantic events: reveal bought, replay used, buzz seat, answer outcome, clue completion, and session completion. Decide the retention/consent policy before emitting anything off-device.
+2. **Phone buzzers on a local room code.** Keep the reducer authoritative; add an `InputGateway` that stamps monotonic receipt time and applies calibrated latency offsets. Do not put WebSockets inside `round.js`, even if they look cold.
+3. **Host and sting director.** Consume existing semantic events for countdowns, lockout sounds, correct/wrong stings, and optional spoken banter. Audio cues need independent volume and captions/status equivalents.
+4. **Signed episode repository.** Load bundled manifests first, then signed remote packs with schema, checksum, editorial, territory, and expiry gates before a clue enters rotation.
+5. **Calibration and loudness.** Add pre-session output calibration, LUFS targets for assets, fades at excerpt boundaries, and a silent-mode accessibility path.
+6. **Answer adjudication tiers.** Preserve authored exact aliases as canonical. Consider editorially authored token/fuzzy rules only after logging false-negative examples; never hand the final score to an unbounded language model with a charming explanation.
+
+## Later — only after the loop earns it
+
+- Curated historical sample-lineage packs with explicit interactive-game rights.
+- Daily crates, seeded challenges, and shareable result cards with no copyrighted audio embedded.
+- Team play, tournaments, audience voting, and DJ-hosted live events.
+- Creator tooling for excerpt selection, checksum generation, alias review, and rights evidence.
+- Cross-device profiles, accessibility preferences, achievements, and seasonal ladders.
+- Spectator presentation, broadcast overlays, camera direction, and host performance capture.
+
+## Measurement plan
+
+The proving build should graduate only when blind sessions support the following:
+
+| Signal | Definition | Proving target |
+| --- | --- | --- |
+| Session completion | Reaches the finale after starting clue one | ≥ 70% |
+| First-clip recognition | Correct on the 0.25-second reveal | Track by clue; no universal target |
+| Reveal tension | At least one guess or buzz before the 5-second reveal | ≥ 65% of clues |
+| Room reaction | Observer marks spontaneous laugh, shout, argument, or sing-along | ≥ 60% of rounds |
+| Replay demand | Players voluntarily start another crate | ≥ 40% of completed rooms |
+| Input fairness | Disputed buzz adjudications | < 2% of buzzes |
+| Technical failure | Audio, boot, or unrecoverable state error | < 0.5% of sessions |
+
+Metrics are evidence, not a tiny spreadsheet monarch. Qualitative observation remains essential because “the room shouted at once” is often the product.
+
+## Release gates
+
+- Reducer actions remain serializable and deterministic.
+- No answer or reveal purchase is possible before playback completes.
+- Every wrong party answer permits an eligible steal.
+- No blocked player can reclaim the same reveal.
+- Audio failures recover without awarding a listen.
+- Keyboard buzzing never mutates an answer field.
+- All demo audio remains original and all future assets remain checksum- and rights-gated.
+- JavaScript lint has zero errors, CSS lint passes, content validation passes, all tests pass, both Vite entries build, browser runtime check passes, and the live Pages URL is smoke-tested after merge.
+
+## Explicit non-goals for 1.2
+
+- No user accounts.
+- No network dependency in the critical play loop.
+- No copyrighted commercial recordings.
+- No AI answer judge.
+- No phone controllers until local couch play proves the room dynamic.
+
+That restraint is not lack of ambition. It is ambition wearing eye protection.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chrome:rdp": "powershell -ExecutionPolicy Bypass -File scripts/start-chrome-rdp.ps1",
     "snap": "node scripts/playwright-sample.mjs",
     "runtime:check": "node scripts/runtime-state-check.mjs",
+    "needle-drop:runtime-check": "node scripts/needle-drop-runtime-check.mjs",
     "purge:css": "purgecss --config purgecss.config.cjs --output dist/assets",
     "trebek:inventory": "node scripts/catalog-trebek-audio.mjs",
     "trebek:transcribe": "node scripts/transcribe-trebek-audio.mjs",

--- a/scripts/needle-drop-runtime-check.mjs
+++ b/scripts/needle-drop-runtime-check.mjs
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:4173';
+const OUT_DIR = path.resolve('screenshots/needle-drop-runtime');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function stateSnapshot(page) {
+  return page.evaluate(() => {
+    const answer = document.querySelector('#answer');
+    const more = document.querySelector('[data-action="more"]');
+    const play = document.querySelector('[data-action="play"]');
+    const game = document.querySelector('#game');
+    return {
+      phase: game?.dataset.phase,
+      revealIndex: Number(game?.dataset.revealIndex),
+      answerDisabled: Boolean(answer?.disabled),
+      moreDisabled: Boolean(more?.disabled),
+      playDisabled: Boolean(play?.disabled),
+      horizontalOverflow: document.documentElement.scrollWidth > window.innerWidth + 2,
+    };
+  });
+}
+
+async function runPartyFlow(browser) {
+  const page = await browser.newPage({ viewport: { width: 1365, height: 900 } });
+  const runtimeErrors = [];
+  page.on('pageerror', error => runtimeErrors.push(error.message));
+  page.on('console', message => {
+    if (message.type() === 'error') runtimeErrors.push(message.text());
+  });
+
+  await page.goto(`${BASE_URL}/needle-drop.html?players=4`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#game[data-phase="ready"]');
+
+  let snapshot = await stateSnapshot(page);
+  assert(snapshot.answerDisabled, 'answer must be locked before playback');
+  assert(snapshot.moreDisabled, 'more-audio purchase must be locked before playback');
+  assert(!snapshot.playDisabled, 'first reveal must be playable');
+  assert(!snapshot.horizontalOverflow, 'desktop layout must not overflow horizontally');
+  assert(await page.locator('.players article').count() === 4, 'four-player room must render four seats');
+
+  await page.getByRole('button', { name: /Drop the needle/ }).click();
+  await page.waitForSelector('#game[data-phase="answering"]');
+  snapshot = await stateSnapshot(page);
+  assert(snapshot.answerDisabled, 'party answer remains locked until a player buzzes');
+  assert(!snapshot.moreDisabled, 'longer reveal becomes available after playback');
+
+  await page.keyboard.press('1');
+  await page.waitForSelector('[data-player-id="player-1"].is-active');
+  assert(!(await page.locator('#answer').isDisabled()), 'buzz winner must receive the answer field');
+  await page.locator('#answer').fill('The Completely Wrong Groove');
+  await page.getByRole('button', { name: 'Lock it' }).click();
+  await page.waitForSelector('[data-player-id="player-1"].is-blocked');
+  assert((await page.locator('#game').getAttribute('data-phase')) === 'answering', 'wrong answer must keep the steal window open');
+
+  await page.keyboard.press('2');
+  await page.waitForSelector('[data-player-id="player-2"].is-active');
+  await page.locator('#answer').fill('Rubber Duck Funk');
+  await page.getByRole('button', { name: 'Lock it' }).click();
+  await page.waitForSelector('#game[data-phase="resolved"]');
+  assert(await page.getByRole('heading', { name: 'Rubber Duck Funk' }).isVisible(), 'correct steal must reveal the record');
+  assert((await page.locator('[data-player-id="player-2"] .players__score').textContent()).trim() === '1,000', 'steal winner must receive the points');
+
+  await page.screenshot({ path: path.join(OUT_DIR, 'party-steal-result.png'), fullPage: true });
+  assert(runtimeErrors.length === 0, `browser emitted runtime errors: ${runtimeErrors.join(' | ')}`);
+  await page.close();
+}
+
+async function runMobileLayout(browser) {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  const runtimeErrors = [];
+  page.on('pageerror', error => runtimeErrors.push(error.message));
+
+  await page.goto(`${BASE_URL}/needle-drop.html?players=4`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#game[data-phase="ready"]');
+  const snapshot = await stateSnapshot(page);
+  assert(!snapshot.horizontalOverflow, 'mobile layout must not overflow horizontally');
+  assert(await page.getByText('How to play').isVisible(), 'mobile onboarding must remain discoverable');
+  assert(await page.getByRole('link', { name: '4P' }).getAttribute('aria-current') === 'page', 'active player count must be announced');
+  await page.screenshot({ path: path.join(OUT_DIR, 'mobile-ready.png'), fullPage: true });
+  assert(runtimeErrors.length === 0, `mobile page emitted runtime errors: ${runtimeErrors.join(' | ')}`);
+  await page.close();
+}
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  try {
+    await runPartyFlow(browser);
+    await runMobileLayout(browser);
+    console.log(`Needle Drop runtime check passed. Evidence: ${OUT_DIR}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch(error => {
+  console.error('[needle-drop-runtime-check] FAILED:', error.message);
+  process.exitCode = 1;
+});

--- a/src/modes/needle-drop/core/content.js
+++ b/src/modes/needle-drop/core/content.js
@@ -1,38 +1,269 @@
-const note=(frequency,duration,gain=.18,type='sine')=>({frequency,duration,gain,type});
-const reveals=()=>[{duration:.25,points:1000,label:'Needle Drop'},{duration:.75,points:750,label:'One Beat'},{duration:2,points:500,label:'The Loop'},{duration:5,points:250,label:'Full Alibi'}];
-const rights=id=>({id:`rights-${id}`,basis:'original-commission',owner:'Needle Drop Demo Catalog',territories:['worldwide'],startsOn:'2026-08-21',expiresOn:'2036-08-21',interactiveGame:true,approvedMaxSeconds:5});
-const synth=sequence=>({kind:'synth',sequence});
+const note = (frequency, duration, gain = 0.18, type = 'sine') => ({
+  frequency,
+  duration,
+  gain,
+  type,
+});
 
-export const demoEpisode=Object.freeze({schemaVersion:1,packageVersion:'1.1.0',id:'nd-demo-001',title:'The Unlicensed Basement Tapes',description:'Four original musical families. No catalog lawyers were awakened.',status:'editorial-demo',release:{channel:'demo',immutable:true,rightsGate:'required'},clues:[
-  {id:'rubber-duck-funk',category:'Bassline Witness Protection',prompt:'Name this suspiciously buoyant original groove.',title:'Rubber Duck Funk',artist:'The Cleared Samples',acceptedAnswers:['Rubber Duck Funk','Rubber Duck'],source:{title:'Bathwater Break',artist:'DJ Public Domain Adjacent',year:2026},transformation:['pitch +3','low-pass filter','two-beat chop'],palette:['#ff3f81','#ffb000'],audio:synth([note(110,.12,.26,'square'),note(146.83,.12,.22,'square'),note(164.81,.12,.20,'square'),note(146.83,.12,.22,'square'),note(220,.18,.18,'sawtooth')]),rights:rights('rubber-duck-funk'),reveals:reveals()},
-  {id:'midnight-pager',category:'Things Heard Through a Wall',prompt:'Identify the nocturnal synth communiqué.',title:'Midnight Pager',artist:'Dial Tone Jones',acceptedAnswers:['Midnight Pager','Pager'],source:{title:'Busy Signal No. 9',artist:'The Operators',year:2026},transformation:['half-time','tape wobble','minor reharmonization'],palette:['#735cdd','#00d7d7'],audio:synth([note(261.63,.18,.16,'triangle'),note(311.13,.18,.16,'triangle'),note(392,.28,.18,'sine'),note(349.23,.18,.16,'triangle')]),rights:rights('midnight-pager'),reveals:reveals()},
-  {id:'municipal-cowbell',category:'More Cowbell, Less Zoning',prompt:'Name the civic percussion emergency.',title:'Municipal Cowbell',artist:'The Department of Funk',acceptedAnswers:['Municipal Cowbell','Cowbell'],source:{title:'Permit Denied',artist:'City Hall & Oates',year:2026},transformation:['cowbell extraction','tempo +12%','bureaucratic delay'],palette:['#f4b942','#c83e4d'],audio:synth([note(540,.08,.20,'square'),note(130.81,.20,.18,'sawtooth'),note(540,.08,.20,'square'),note(196,.20,.18,'sawtooth')]),rights:rights('municipal-cowbell'),reveals:reveals()},
-  {id:'last-train-neptune',category:'Six Degrees of Outer Space',prompt:'Identify the final interplanetary departure.',title:'Last Train to Neptune',artist:'Cosmic Rail Authority',acceptedAnswers:['Last Train to Neptune','Neptune'],source:{title:'Platform Infinity',artist:'Saturn Transit Choir',year:2026},transformation:['reverse envelope','octave stack','zero-gravity swing'],palette:['#00d7d7','#37b36b'],audio:synth([note(196,.22,.14,'sine'),note(246.94,.22,.14,'sine'),note(293.66,.22,.14,'sine'),note(392,.38,.16,'triangle')]),rights:rights('last-train-neptune'),reveals:reveals()}
-]});
+const reveals = () => [
+  { duration: 0.25, points: 1000, label: 'Needle Drop' },
+  { duration: 0.75, points: 750, label: 'One Beat' },
+  { duration: 2, points: 500, label: 'The Loop' },
+  { duration: 5, points: 250, label: 'Full Alibi' },
+];
 
-export function validateEpisode(episode,asOf='2026-08-21'){
-  const errors=[];
-  if(episode?.schemaVersion!==1)errors.push('schemaVersion must be 1');
-  if(!episode?.packageVersion)errors.push('episode.packageVersion is required');
-  if(!episode?.id)errors.push('episode.id is required');
-  if(!episode?.release?.immutable)errors.push('episode.release must be immutable');
-  if(!Array.isArray(episode?.clues)||!episode.clues.length)errors.push('episode.clues must be non-empty');
-  const ids=new Set();
-  for(const [index,clue] of (episode?.clues||[]).entries()){
-    const path=`clues[${index}]`;
-    if(!clue.id)errors.push(`${path}.id is required`); if(ids.has(clue.id))errors.push(`${path}.id must be unique`); ids.add(clue.id);
-    if(!clue.title||!clue.artist)errors.push(`${path} requires title and artist`);
-    if(!Array.isArray(clue.acceptedAnswers)||!clue.acceptedAnswers.includes(clue.title))errors.push(`${path}.acceptedAnswers must include title`);
-    if(!Array.isArray(clue.reveals)||clue.reveals.length<2)errors.push(`${path}.reveals requires at least two stages`);
-    for(let i=1;i<(clue.reveals||[]).length;i++){if(clue.reveals[i].duration<=clue.reveals[i-1].duration)errors.push(`${path}.reveals durations must increase`);if(clue.reveals[i].points>=clue.reveals[i-1].points)errors.push(`${path}.reveals points must decrease`);}
-    if(!['synth','asset'].includes(clue.audio?.kind))errors.push(`${path}.audio.kind must be synth or asset`);
-    if(clue.audio?.kind==='synth'&&(!Array.isArray(clue.audio.sequence)||!clue.audio.sequence.length))errors.push(`${path}.audio.sequence is required`);
-    if(clue.audio?.kind==='asset'&&(!clue.audio.url||!/^[a-f0-9]{64}$/i.test(clue.audio.sha256||'')))errors.push(`${path}.audio asset requires url and sha256`);
-    if(!clue.rights?.interactiveGame)errors.push(`${path}.rights must allow interactive game use`);
-    if(!clue.rights?.territories?.length)errors.push(`${path}.rights territories are required`);
-    if(!clue.rights?.startsOn||clue.rights.startsOn>asOf)errors.push(`${path}.rights have not started`);
-    if(!clue.rights?.expiresOn||clue.rights.expiresOn<asOf)errors.push(`${path}.rights are expired`);
-    const largestReveal=Math.max(...(clue.reveals||[]).map(item=>item.duration)); if(largestReveal>(clue.rights?.approvedMaxSeconds||0))errors.push(`${path}.reveal exceeds rights scope`);
+const rights = id => ({
+  id: `rights-${id}`,
+  basis: 'original-commission',
+  owner: 'Needle Drop Demo Catalog',
+  territories: ['worldwide'],
+  startsOn: '2026-08-21',
+  expiresOn: '2036-08-21',
+  interactiveGame: true,
+  approvedMaxSeconds: 5,
+});
+
+const synth = sequence => ({ kind: 'synth', sequence });
+
+export const demoEpisode = Object.freeze({
+  schemaVersion: 1,
+  packageVersion: '1.2.0',
+  id: 'nd-demo-001',
+  title: 'The Unlicensed Basement Tapes',
+  description: 'Eight original musical families. No catalog lawyers were awakened.',
+  status: 'editorial-demo',
+  release: { channel: 'demo', immutable: true, rightsGate: 'required' },
+  clues: [
+    {
+      id: 'rubber-duck-funk',
+      category: 'Bassline Witness Protection',
+      prompt: 'Name this suspiciously buoyant original groove.',
+      title: 'Rubber Duck Funk',
+      artist: 'The Cleared Samples',
+      acceptedAnswers: ['Rubber Duck Funk', 'Rubber Duck'],
+      source: { title: 'Bathwater Break', artist: 'DJ Public Domain Adjacent', year: 2026 },
+      transformation: ['pitch +3', 'low-pass filter', 'two-beat chop'],
+      linerNote: 'The bass was questioned for three hours and still refused to name the drummer.',
+      palette: ['#ff3f81', '#ffb000'],
+      audio: synth([
+        note(110, 0.12, 0.26, 'square'),
+        note(146.83, 0.12, 0.22, 'square'),
+        note(164.81, 0.12, 0.2, 'square'),
+        note(146.83, 0.12, 0.22, 'square'),
+        note(220, 0.18, 0.18, 'sawtooth'),
+      ]),
+      rights: rights('rubber-duck-funk'),
+      reveals: reveals(),
+    },
+    {
+      id: 'midnight-pager',
+      category: 'Things Heard Through a Wall',
+      prompt: 'Identify the nocturnal synth communiqué.',
+      title: 'Midnight Pager',
+      artist: 'Dial Tone Jones',
+      acceptedAnswers: ['Midnight Pager', 'Pager'],
+      source: { title: 'Busy Signal No. 9', artist: 'The Operators', year: 2026 },
+      transformation: ['half-time', 'tape wobble', 'minor reharmonization'],
+      linerNote: 'Recorded after midnight, when every synthesizer believes it is the main character.',
+      palette: ['#735cdd', '#00d7d7'],
+      audio: synth([
+        note(261.63, 0.18, 0.16, 'triangle'),
+        note(311.13, 0.18, 0.16, 'triangle'),
+        note(392, 0.28, 0.18),
+        note(349.23, 0.18, 0.16, 'triangle'),
+      ]),
+      rights: rights('midnight-pager'),
+      reveals: reveals(),
+    },
+    {
+      id: 'municipal-cowbell',
+      category: 'More Cowbell, Less Zoning',
+      prompt: 'Name the civic percussion emergency.',
+      title: 'Municipal Cowbell',
+      artist: 'The Department of Funk',
+      acceptedAnswers: ['Municipal Cowbell', 'Cowbell'],
+      source: { title: 'Permit Denied', artist: 'City Hall & Oates', year: 2026 },
+      transformation: ['cowbell extraction', 'tempo +12%', 'bureaucratic delay'],
+      linerNote: 'The permit was denied, but the cowbell had already sublet the chorus.',
+      palette: ['#f4b942', '#c83e4d'],
+      audio: synth([
+        note(540, 0.08, 0.2, 'square'),
+        note(130.81, 0.2, 0.18, 'sawtooth'),
+        note(540, 0.08, 0.2, 'square'),
+        note(196, 0.2, 0.18, 'sawtooth'),
+      ]),
+      rights: rights('municipal-cowbell'),
+      reveals: reveals(),
+    },
+    {
+      id: 'last-train-neptune',
+      category: 'Six Degrees of Outer Space',
+      prompt: 'Identify the final interplanetary departure.',
+      title: 'Last Train to Neptune',
+      artist: 'Cosmic Rail Authority',
+      acceptedAnswers: ['Last Train to Neptune', 'Neptune'],
+      source: { title: 'Platform Infinity', artist: 'Saturn Transit Choir', year: 2026 },
+      transformation: ['reverse envelope', 'octave stack', 'zero-gravity swing'],
+      linerNote: 'Service to Neptune remains delayed because space is, frankly, quite large.',
+      palette: ['#00d7d7', '#37b36b'],
+      audio: synth([
+        note(196, 0.22, 0.14),
+        note(246.94, 0.22, 0.14),
+        note(293.66, 0.22, 0.14),
+        note(392, 0.38, 0.16, 'triangle'),
+      ]),
+      rights: rights('last-train-neptune'),
+      reveals: reveals(),
+    },
+    {
+      id: 'velvet-parking-ticket',
+      category: 'Citation Needed, but Make It Funk',
+      prompt: 'Identify this luxurious municipal inconvenience.',
+      title: 'Velvet Parking Ticket',
+      artist: 'Citation Nation',
+      acceptedAnswers: ['Velvet Parking Ticket', 'Parking Ticket'],
+      source: { title: 'Meter Maid in G Minor', artist: 'The Tow-Aways', year: 2026 },
+      transformation: ['wah envelope', 'bass octave', 'thirty-day appeal'],
+      linerNote: 'The groove was parked illegally and towed directly into the bridge.',
+      palette: ['#ff6b35', '#f7c548'],
+      audio: synth([
+        note(98, 0.12, 0.2, 'sawtooth'),
+        note(130.81, 0.12, 0.18, 'square'),
+        note(146.83, 0.1, 0.18, 'square'),
+        note(196, 0.2, 0.16, 'triangle'),
+      ]),
+      rights: rights('velvet-parking-ticket'),
+      reveals: reveals(),
+    },
+    {
+      id: 'ghosted-by-the-groove',
+      category: 'Unanswered Texts in 4/4',
+      prompt: 'Name the rhythm that left you on read.',
+      title: 'Ghosted by the Groove',
+      artist: 'Seen at 2:03 AM',
+      acceptedAnswers: ['Ghosted by the Groove', 'Ghosted', 'The Groove'],
+      source: { title: 'Read Receipt Riddim', artist: 'Typing Indicator', year: 2026 },
+      transformation: ['vocal absence', 'double text', 'read-receipt reverb'],
+      linerNote: 'It promised to call after the chorus. The chorus has retained counsel.',
+      palette: ['#8d6cff', '#ff3f81'],
+      audio: synth([
+        note(220, 0.16, 0.14, 'sine'),
+        note(277.18, 0.12, 0.16, 'triangle'),
+        note(329.63, 0.16, 0.16, 'triangle'),
+        note(246.94, 0.24, 0.12, 'sine'),
+      ]),
+      rights: rights('ghosted-by-the-groove'),
+      reveals: reveals(),
+    },
+    {
+      id: 'disco-laundromat',
+      category: 'Loads of Rhythm',
+      prompt: 'Identify this permanent-press dance-floor cycle.',
+      title: 'Disco Laundromat',
+      artist: 'Spin Cycle Social Club',
+      acceptedAnswers: ['Disco Laundromat', 'Laundromat'],
+      source: { title: 'Fabric Softener After Dark', artist: 'The Delicates', year: 2026 },
+      transformation: ['four-on-the-floor', 'lint filter', 'extra rinse'],
+      linerNote: 'Dry-clean only, except for the bassline, which absolutely insists on getting wet.',
+      palette: ['#00d7d7', '#f25f5c'],
+      audio: synth([
+        note(130.81, 0.1, 0.2, 'square'),
+        note(261.63, 0.1, 0.13, 'sawtooth'),
+        note(164.81, 0.1, 0.18, 'square'),
+        note(329.63, 0.16, 0.13, 'sawtooth'),
+      ]),
+      rights: rights('disco-laundromat'),
+      reveals: reveals(),
+    },
+    {
+      id: 'emergency-saxophone',
+      category: 'Smooth Jazz First Responders',
+      prompt: 'Name the melody arriving with lights and sirens.',
+      title: 'Emergency Saxophone',
+      artist: 'The Alto Responders',
+      acceptedAnswers: ['Emergency Saxophone', 'Emergency Sax', 'Saxophone'],
+      source: { title: 'Code Blue Note', artist: 'Triage by Moonlight', year: 2026 },
+      transformation: ['portamento', 'night-shift vibrato', 'urgent key change'],
+      linerNote: 'The solo is stable, but doctors recommend several weeks away from the bridge.',
+      palette: ['#ef476f', '#06d6a0'],
+      audio: synth([
+        note(293.66, 0.18, 0.14, 'sawtooth'),
+        note(349.23, 0.16, 0.15, 'triangle'),
+        note(392, 0.22, 0.16, 'sawtooth'),
+        note(440, 0.28, 0.14, 'triangle'),
+      ]),
+      rights: rights('emergency-saxophone'),
+      reveals: reveals(),
+    },
+  ],
+});
+
+export function validateEpisode(episode, asOf = new Date().toISOString().slice(0, 10)) {
+  const errors = [];
+  if (episode?.schemaVersion !== 1) errors.push('schemaVersion must be 1');
+  if (!episode?.packageVersion) errors.push('episode.packageVersion is required');
+  if (!episode?.id) errors.push('episode.id is required');
+  if (!episode?.release?.immutable) errors.push('episode.release must be immutable');
+  if (!Array.isArray(episode?.clues) || !episode.clues.length) {
+    errors.push('episode.clues must be non-empty');
   }
+
+  const ids = new Set();
+  for (const [index, clue] of (episode?.clues || []).entries()) {
+    const path = `clues[${index}]`;
+    if (!clue.id) errors.push(`${path}.id is required`);
+    if (ids.has(clue.id)) errors.push(`${path}.id must be unique`);
+    ids.add(clue.id);
+    if (!clue.title || !clue.artist) errors.push(`${path} requires title and artist`);
+    if (!clue.source?.title || !clue.source?.artist) errors.push(`${path}.source is required`);
+    if (!clue.linerNote) errors.push(`${path}.linerNote is required`);
+    if (!Array.isArray(clue.transformation) || !clue.transformation.length) {
+      errors.push(`${path}.transformation is required`);
+    }
+    if (!Array.isArray(clue.acceptedAnswers) || !clue.acceptedAnswers.includes(clue.title)) {
+      errors.push(`${path}.acceptedAnswers must include title`);
+    }
+    if (!Array.isArray(clue.reveals) || clue.reveals.length < 2) {
+      errors.push(`${path}.reveals requires at least two stages`);
+    }
+    for (let revealIndex = 1; revealIndex < (clue.reveals || []).length; revealIndex += 1) {
+      if (clue.reveals[revealIndex].duration <= clue.reveals[revealIndex - 1].duration) {
+        errors.push(`${path}.reveals durations must increase`);
+      }
+      if (clue.reveals[revealIndex].points >= clue.reveals[revealIndex - 1].points) {
+        errors.push(`${path}.reveals points must decrease`);
+      }
+    }
+    if (!['synth', 'asset'].includes(clue.audio?.kind)) {
+      errors.push(`${path}.audio.kind must be synth or asset`);
+    }
+    if (clue.audio?.kind === 'synth') {
+      if (!Array.isArray(clue.audio.sequence) || !clue.audio.sequence.length) {
+        errors.push(`${path}.audio.sequence is required`);
+      }
+      if (clue.audio.sequence?.some(item => item.duration <= 0 || item.frequency <= 0)) {
+        errors.push(`${path}.audio.sequence notes must have positive frequency and duration`);
+      }
+    }
+    if (clue.audio?.kind === 'asset'
+      && (!clue.audio.url || !/^[a-f0-9]{64}$/i.test(clue.audio.sha256 || ''))) {
+      errors.push(`${path}.audio asset requires url and sha256`);
+    }
+    if (!clue.rights?.interactiveGame) {
+      errors.push(`${path}.rights must allow interactive game use`);
+    }
+    if (!clue.rights?.territories?.length) errors.push(`${path}.rights territories are required`);
+    if (!clue.rights?.startsOn || clue.rights.startsOn > asOf) {
+      errors.push(`${path}.rights have not started`);
+    }
+    if (!clue.rights?.expiresOn || clue.rights.expiresOn < asOf) {
+      errors.push(`${path}.rights are expired`);
+    }
+    const largestReveal = Math.max(...(clue.reveals || []).map(item => item.duration));
+    if (largestReveal > (clue.rights?.approvedMaxSeconds || 0)) {
+      errors.push(`${path}.reveal exceeds rights scope`);
+    }
+  }
+
   return errors;
 }

--- a/src/modes/needle-drop/core/party.js
+++ b/src/modes/needle-drop/core/party.js
@@ -1,6 +1,52 @@
-const PLAYER_COLORS=['#ff3f81','#00d7d7','#f4b942','#735cdd'];
-const BUZZ_KEYS=['1','2','3','4'];
-export function createPlayers(count=1){const safeCount=Math.max(1,Math.min(4,Number(count)||1));return Array.from({length:safeCount},(_,index)=>({id:`player-${index+1}`,name:safeCount===1?'Solo Crate Digger':`Player ${index+1}`,color:PLAYER_COLORS[index],buzzKey:BUZZ_KEYS[index],score:0}));}
-export function claimBuzz(players,activePlayerId,playerId){if(activePlayerId||!players.some(player=>player.id===playerId))return activePlayerId;return playerId;}
-export function awardPlayer(players,playerId,points){return players.map(player=>player.id===playerId?{...player,score:player.score+points}:player);}
-export function playerForKey(players,key){return players.find(player=>player.buzzKey===key)||null;}
+const PLAYER_COLORS = ['#ff3f81', '#00d7d7', '#f4b942', '#8d6cff'];
+const BUZZ_KEYS = ['1', '2', '3', '4'];
+
+export function createPlayers(count = 1) {
+  const safeCount = Math.max(1, Math.min(4, Number(count) || 1));
+
+  return Array.from({ length: safeCount }, (_, index) => ({
+    id: `player-${index + 1}`,
+    name: safeCount === 1 ? 'Solo Crate Digger' : `Player ${index + 1}`,
+    color: PLAYER_COLORS[index],
+    buzzKey: BUZZ_KEYS[index],
+    score: 0,
+    streak: 0,
+    correct: 0,
+    attempts: 0,
+  }));
+}
+
+export function claimBuzz(players, activePlayerId, playerId, blockedPlayerIds = []) {
+  if (activePlayerId || blockedPlayerIds.includes(playerId)) return activePlayerId;
+  return players.some(player => player.id === playerId) ? playerId : activePlayerId;
+}
+
+export function recordPlayerAttempt(players, playerId, { accepted, points }) {
+  return players.map(player => {
+    if (player.id !== playerId) return player;
+
+    return {
+      ...player,
+      score: player.score + points,
+      streak: accepted ? player.streak + 1 : 0,
+      correct: player.correct + (accepted ? 1 : 0),
+      attempts: player.attempts + 1,
+    };
+  });
+}
+
+export function awardPlayer(players, playerId, points) {
+  return recordPlayerAttempt(players, playerId, { accepted: points > 0, points });
+}
+
+export function rankPlayers(players) {
+  return [...players].sort((left, right) => (
+    right.score - left.score
+    || right.correct - left.correct
+    || left.id.localeCompare(right.id)
+  ));
+}
+
+export function playerForKey(players, key) {
+  return players.find(player => player.buzzKey === key) || null;
+}

--- a/src/modes/needle-drop/core/round.js
+++ b/src/modes/needle-drop/core/round.js
@@ -1,50 +1,234 @@
-import { awardPlayer, claimBuzz, createPlayers } from './party.js';
+import { claimBuzz, createPlayers, recordPlayerAttempt } from './party.js';
 
-export const ROUND_PHASES = Object.freeze({ READY:'ready', LISTENING:'listening', ANSWERING:'answering', RESOLVED:'resolved', COMPLETE:'complete' });
+export const ROUND_PHASES = Object.freeze({
+  READY: 'ready',
+  LISTENING: 'listening',
+  ANSWERING: 'answering',
+  RESOLVED: 'resolved',
+  COMPLETE: 'complete',
+});
 
 export function normalizeAnswer(value = '') {
-  return value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/&/g, ' and ').replace(/[^a-z0-9]+/g, ' ').trim().replace(/^(the|a|an)\s+/, '').replace(/\s+/g, ' ');
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
 }
 
 export function isAcceptedAnswer(answer, acceptedAnswers) {
   const normalized = normalizeAnswer(answer);
-  return normalized.length > 0 && acceptedAnswers.some(candidate => normalizeAnswer(candidate) === normalized);
+  return normalized.length > 0
+    && acceptedAnswers.some(candidate => normalizeAnswer(candidate) === normalized);
 }
 
-export function scoreForReveal(reveal, streak = 0) { return Math.max(0, reveal.points + Math.min(streak, 4) * 50); }
+export function scoreForReveal(reveal, streak = 0) {
+  return Math.max(0, reveal.points + Math.min(streak, 4) * 50);
+}
 
-export function createInitialState(episode, options={}) {
-  const players=createPlayers(options.playerCount);
-  return { phase:ROUND_PHASES.READY, episodeId:episode.id, clueIndex:0, revealIndex:0, score:0, streak:0, correct:0, players, activePlayerId:players.length===1?players[0].id:null, attempts:[], result:null };
+export function currentClueAttempts(state, clueId) {
+  return state.attempts.filter(attempt => attempt.clueId === clueId);
+}
+
+export function createInitialState(episode, options = {}) {
+  const players = createPlayers(options.playerCount);
+
+  return {
+    phase: ROUND_PHASES.READY,
+    episodeId: episode.id,
+    clueIndex: 0,
+    revealIndex: 0,
+    listenedRevealIndex: -1,
+    score: 0,
+    streak: 0,
+    correct: 0,
+    players,
+    activePlayerId: null,
+    blockedPlayerIds: [],
+    attempts: [],
+    lastAttempt: null,
+    result: null,
+    audioError: null,
+  };
+}
+
+function resolveMiss(state, attempt) {
+  return {
+    ...state,
+    phase: ROUND_PHASES.RESOLVED,
+    activePlayerId: null,
+    result: { ...attempt, exhausted: true },
+    lastAttempt: attempt,
+  };
 }
 
 export function reduceRound(state, action, episode) {
   const clue = episode.clues[state.clueIndex];
+
   switch (action.type) {
-    case 'PLAY_REVEAL':
-      if ([ROUND_PHASES.RESOLVED, ROUND_PHASES.COMPLETE].includes(state.phase)) return state;
-      return { ...state, phase:ROUND_PHASES.LISTENING };
-    case 'REVEAL_FINISHED': return state.phase === ROUND_PHASES.LISTENING ? { ...state, phase:ROUND_PHASES.ANSWERING } : state;
-    case 'BUZZ':
-      if(state.phase!==ROUND_PHASES.ANSWERING)return state;
-      return {...state,activePlayerId:claimBuzz(state.players,state.activePlayerId,action.playerId)};
-    case 'MORE_AUDIO':
-      if (state.phase === ROUND_PHASES.RESOLVED || state.revealIndex >= clue.reveals.length - 1) return state;
-      return { ...state, revealIndex:state.revealIndex + 1, phase:ROUND_PHASES.READY };
-    case 'SUBMIT_ANSWER': {
-      if ([ROUND_PHASES.RESOLVED, ROUND_PHASES.COMPLETE].includes(state.phase)) return state;
-      const accepted = isAcceptedAnswer(action.answer, clue.acceptedAnswers);
-      const points = accepted ? scoreForReveal(clue.reveals[state.revealIndex], state.streak) : 0;
-      if(!state.activePlayerId)return state;
-      const attempt = { clueId:clue.id, playerId:state.activePlayerId, answer:action.answer, accepted, revealIndex:state.revealIndex, points };
-      return { ...state, phase:ROUND_PHASES.RESOLVED, score:state.score + points, streak:accepted ? state.streak + 1 : 0, correct:state.correct + (accepted ? 1 : 0), players:awardPlayer(state.players,state.activePlayerId,points), attempts:[...state.attempts, attempt], result:attempt };
+    case 'PLAY_REVEAL': {
+      const canPlay = [ROUND_PHASES.READY, ROUND_PHASES.ANSWERING].includes(state.phase)
+        && !state.activePlayerId;
+      if (!canPlay) return state;
+      return { ...state, phase: ROUND_PHASES.LISTENING, audioError: null };
     }
+
+    case 'REVEAL_FINISHED': {
+      if (state.phase !== ROUND_PHASES.LISTENING) return state;
+      const soloPlayer = state.players.length === 1 ? state.players[0] : null;
+      const soloCanAnswer = soloPlayer && !state.blockedPlayerIds.includes(soloPlayer.id);
+
+      return {
+        ...state,
+        phase: ROUND_PHASES.ANSWERING,
+        listenedRevealIndex: Math.max(state.listenedRevealIndex, state.revealIndex),
+        activePlayerId: soloCanAnswer ? soloPlayer.id : null,
+      };
+    }
+
+    case 'AUDIO_FAILED':
+      if (state.phase !== ROUND_PHASES.LISTENING) return state;
+      return {
+        ...state,
+        phase: ROUND_PHASES.READY,
+        audioError: action.message || 'Audio could not be played. Try again.',
+      };
+
+    case 'BUZZ': {
+      if (state.phase !== ROUND_PHASES.ANSWERING) return state;
+      const activePlayerId = claimBuzz(
+        state.players,
+        state.activePlayerId,
+        action.playerId,
+        state.blockedPlayerIds,
+      );
+      if (activePlayerId === state.activePlayerId) return state;
+      return { ...state, activePlayerId, lastAttempt: null };
+    }
+
+    case 'MORE_AUDIO': {
+      const heardCurrentReveal = state.listenedRevealIndex >= state.revealIndex;
+      const canBuy = state.phase === ROUND_PHASES.ANSWERING
+        && heardCurrentReveal
+        && !state.activePlayerId
+        && state.revealIndex < clue.reveals.length - 1;
+      if (!canBuy) return state;
+
+      return {
+        ...state,
+        revealIndex: state.revealIndex + 1,
+        phase: ROUND_PHASES.READY,
+        activePlayerId: null,
+        blockedPlayerIds: [],
+        lastAttempt: null,
+        audioError: null,
+      };
+    }
+
+    case 'PASS':
+    case 'SUBMIT_ANSWER': {
+      if (state.phase !== ROUND_PHASES.ANSWERING || !state.activePlayerId) return state;
+
+      const player = state.players.find(item => item.id === state.activePlayerId);
+      if (!player || state.blockedPlayerIds.includes(player.id)) return state;
+
+      const passed = action.type === 'PASS';
+      const accepted = !passed && isAcceptedAnswer(action.answer, clue.acceptedAnswers);
+      const points = accepted ? scoreForReveal(clue.reveals[state.revealIndex], player.streak) : 0;
+      const attempt = {
+        clueId: clue.id,
+        playerId: player.id,
+        answer: passed ? '' : String(action.answer).trim(),
+        accepted,
+        passed,
+        revealIndex: state.revealIndex,
+        points,
+      };
+      const players = recordPlayerAttempt(state.players, player.id, attempt);
+      const attempts = [...state.attempts, attempt];
+
+      if (accepted) {
+        return {
+          ...state,
+          phase: ROUND_PHASES.RESOLVED,
+          score: state.score + points,
+          streak: state.players.length === 1 ? player.streak + 1 : state.streak,
+          correct: state.correct + 1,
+          players,
+          activePlayerId: null,
+          attempts,
+          lastAttempt: attempt,
+          result: attempt,
+        };
+      }
+
+      const blockedPlayerIds = [...state.blockedPlayerIds, player.id];
+      const everyoneMissed = blockedPlayerIds.length === state.players.length;
+      const isLastReveal = state.revealIndex === clue.reveals.length - 1;
+      const nextState = {
+        ...state,
+        streak: state.players.length === 1 ? 0 : state.streak,
+        players,
+        activePlayerId: null,
+        blockedPlayerIds,
+        attempts,
+        lastAttempt: attempt,
+      };
+
+      return everyoneMissed && isLastReveal ? resolveMiss(nextState, attempt) : nextState;
+    }
+
+    case 'GIVE_UP': {
+      const hasHeardAudio = state.listenedRevealIndex >= 0;
+      const canGiveUp = state.phase === ROUND_PHASES.ANSWERING
+        && hasHeardAudio
+        && !state.activePlayerId;
+      if (!canGiveUp) return state;
+
+      const attempt = {
+        clueId: clue.id,
+        playerId: null,
+        answer: '',
+        accepted: false,
+        revealIndex: state.revealIndex,
+        points: 0,
+        gaveUp: true,
+      };
+
+      return resolveMiss({
+        ...state,
+        streak: state.players.length === 1 ? 0 : state.streak,
+        attempts: [...state.attempts, attempt],
+      }, attempt);
+    }
+
     case 'NEXT_CLUE': {
       if (state.phase !== ROUND_PHASES.RESOLVED) return state;
       const clueIndex = state.clueIndex + 1;
-      return clueIndex >= episode.clues.length ? { ...state, phase:ROUND_PHASES.COMPLETE } : { ...state, phase:ROUND_PHASES.READY, clueIndex, revealIndex:0, activePlayerId:state.players.length===1?state.players[0].id:null, result:null };
+      if (clueIndex >= episode.clues.length) return { ...state, phase: ROUND_PHASES.COMPLETE };
+
+      return {
+        ...state,
+        phase: ROUND_PHASES.READY,
+        clueIndex,
+        revealIndex: 0,
+        listenedRevealIndex: -1,
+        activePlayerId: null,
+        blockedPlayerIds: [],
+        lastAttempt: null,
+        result: null,
+        audioError: null,
+      };
     }
-    case 'RESTART': return createInitialState(episode,{playerCount:state.players.length});
-    default: return state;
+
+    case 'RESTART':
+      return createInitialState(episode, { playerCount: state.players.length });
+
+    default:
+      return state;
   }
 }

--- a/src/modes/needle-drop/main.js
+++ b/src/modes/needle-drop/main.js
@@ -2,57 +2,168 @@ import './styles.css';
 import { demoEpisode, validateEpisode } from './core/content.js';
 import { playerForKey } from './core/party.js';
 import { createInitialState, reduceRound, ROUND_PHASES } from './core/round.js';
+import { renderApp } from './presentation/markup.js';
 import { Waveform } from './presentation/Waveform.js';
 import { AudioRuntime } from './services/audioRuntime.js';
+import { ProfileStore } from './services/profileStore.js';
 
-const errors=validateEpisode(demoEpisode);
-if(errors.length)throw new Error(`Needle Drop content invalid:\n${errors.join('\n')}`);
+const errors = validateEpisode(demoEpisode);
+if (errors.length) throw new Error(`Needle Drop content invalid:\n${errors.join('\n')}`);
 
-const app=document.querySelector('#needle-drop-app');
-const audio=new AudioRuntime();
-const requestedPlayers=new URLSearchParams(window.location.search).get('players');
-let state=createInitialState(demoEpisode,{playerCount:requestedPlayers});
+const app = document.querySelector('#needle-drop-app');
+if (!app) throw new Error('Needle Drop mount point is missing. The crate cannot levitate.');
+
+const audio = new AudioRuntime();
+const profileStore = new ProfileStore();
+const requestedPlayers = new URLSearchParams(window.location.search).get('players');
+
+let state = createInitialState(demoEpisode, { playerCount: requestedPlayers });
+let profile = profileStore.read();
 let waveform;
+let playbackToken = 0;
+let isNewBest = false;
 
-function emit(name,detail={}){window.dispatchEvent(new CustomEvent(`needle-drop:${name}`,{detail:{...detail,state}}));}
-function dispatch(action){const previous=state;state=reduceRound(state,action,demoEpisode);emit(action.type.toLowerCase(),{action,previous});render();}
-
-async function playCurrentReveal(){
-  if(state.phase===ROUND_PHASES.LISTENING)return;
-  dispatch({type:'PLAY_REVEAL'});
-  const clue=demoEpisode.clues[state.clueIndex],reveal=clue.reveals[state.revealIndex];
-  waveform.animate(reveal.duration*1000);
-  await audio.play(clue,reveal);
-  dispatch({type:'REVEAL_FINISHED'});
-  if(state.activePlayerId)document.querySelector('#answer')?.focus();
+function emit(name, detail = {}) {
+  window.dispatchEvent(new CustomEvent(`needle-drop:${name}`, {
+    detail: { ...detail, state },
+  }));
 }
 
-function lineageMarkup(clue){return `<div class="lineage" aria-label="Sample lineage"><article><span>ORIGINAL SOURCE</span><strong>${clue.source.title}</strong><small>${clue.source.artist} · ${clue.source.year}</small></article><div class="lineage__arrow" aria-hidden="true">➜<small>${clue.transformation.join(' · ')}</small></div><article><span>THE FLIP</span><strong>${clue.title}</strong><small>${clue.artist}</small></article></div>`;}
-function playersMarkup(){return `<section class="players" aria-label="Players">${state.players.map(player=>`<article class="${state.activePlayerId===player.id?'is-active':''}" style="--player:${player.color}"><kbd>${player.buzzKey}</kbd><span>${player.name}</span><strong>${player.score.toLocaleString()}</strong></article>`).join('')}</section>`;}
-
-function roundMarkup(clue,reveal){
-  const awaitingBuzz=state.players.length>1&&!state.activePlayerId;
-  if(state.phase===ROUND_PHASES.RESOLVED)return `<section class="clue-card"><section class="result ${state.result.accepted?'result--correct':'result--wrong'}"><p class="eyebrow">${state.result.accepted?'CORRECT · MUSICAL WITCHCRAFT DETECTED':'THE RECORD DISAGREES'}</p><h3>${clue.title}</h3><p>${clue.artist}</p><strong>+${state.result.points.toLocaleString()} points</strong></section>${lineageMarkup(clue)}<button class="next" data-action="next">${state.clueIndex===demoEpisode.clues.length-1?'Close the crate':'Next record'} →</button></section>`;
-  return `<section class="clue-card"><div class="clue-card__meta"><span>TRACK ${state.clueIndex+1}/${demoEpisode.clues.length}</span><span>${clue.category}</span></div><h2>${clue.prompt}</h2><div class="turntable"><div class="record ${state.phase===ROUND_PHASES.LISTENING?'record--spinning':''}"><i></i></div><div class="tonearm"></div></div><canvas id="waveform" class="waveform" aria-label="Stylized audio waveform"></canvas><div class="reveal-meter">${clue.reveals.map((item,index)=>`<div class="${index===state.revealIndex?'is-current':''} ${index<state.revealIndex?'is-spent':''}"><span>${item.label}</span><strong>${item.duration}s</strong><small>${item.points} pts</small></div>`).join('')}</div><form id="answer-form" class="answer"><label for="answer">${awaitingBuzz?'Press your player number to buzz':'Your answer'}</label><div><input id="answer" name="answer" autocomplete="off" placeholder="Name that suspicious noise…" ${state.phase===ROUND_PHASES.LISTENING||awaitingBuzz?'disabled':''}/><button type="submit" ${state.phase===ROUND_PHASES.LISTENING||awaitingBuzz?'disabled':''}>Lock it</button></div></form><div class="controls"><button class="button--needle" data-action="play" ${state.phase===ROUND_PHASES.LISTENING?'disabled':''}>${state.phase===ROUND_PHASES.LISTENING?'Listening…':'▶ Drop the needle'}</button><button data-action="more" ${state.revealIndex>=clue.reveals.length-1?'disabled':''}>Buy more audio <small>−${reveal.points-(clue.reveals[state.revealIndex+1]?.points||reveal.points)} potential</small></button></div></section>`;
+function focusAfter(actionType) {
+  window.queueMicrotask(() => {
+    if (state.phase === ROUND_PHASES.COMPLETE) {
+      document.querySelector('#finale-heading')?.focus();
+      return;
+    }
+    if (state.phase === ROUND_PHASES.RESOLVED) {
+      document.querySelector('#result-heading')?.focus();
+      return;
+    }
+    if (state.activePlayerId) {
+      document.querySelector('#answer')?.focus();
+      return;
+    }
+    if (['MORE_AUDIO', 'NEXT_CLUE', 'RESTART', 'AUDIO_FAILED'].includes(actionType)) {
+      document.querySelector('[data-action="play"]')?.focus();
+      return;
+    }
+    if (['SUBMIT_ANSWER', 'PASS'].includes(actionType)) {
+      const nextControl = document.querySelector('[data-action="more"]:not(:disabled)')
+        || document.querySelector('[data-action="give-up"]:not(:disabled)');
+      nextControl?.focus();
+    }
+  });
 }
 
-function render(){
+function render(actionType) {
   waveform?.destroy();
-  const clue=demoEpisode.clues[state.clueIndex],reveal=clue?.reveals[state.revealIndex],complete=state.phase===ROUND_PHASES.COMPLETE;
-  const body=complete?`<section class="finale"><p class="eyebrow">CRATE CLOSED</p><h2>${state.correct}/${demoEpisode.clues.length} identified</h2><p>${state.score.toLocaleString()} points. The waveform has declined to comment.</p><button data-action="restart">Spin it again</button></section>`:roundMarkup(clue,reveal);
-  app.innerHTML=`<main id="game" class="stage" style="--accent:${clue?.palette?.[0]||'#ff3f81'};--accent-2:${clue?.palette?.[1]||'#00d7d7'}"><header class="show-header"><a href="./" class="show-header__universe">JEO<span>PARODY</span> / MUSIC DISTRICT</a><div class="show-header__score"><span>SCORE</span><strong>${state.score.toLocaleString()}</strong></div><div class="show-header__streak"><span>STREAK</span><strong>${state.streak}</strong></div></header><section class="marquee"><span>PROJECT CRATE EXPECTATIONS</span><h1>NEEDLE DROP</h1><p>Musical archaeology conducted at an unsafe volume.</p><nav class="player-count" aria-label="Player count"><a href="?players=1">1P</a><a href="?players=2">2P</a><a href="?players=4">4P</a></nav></section>${playersMarkup()}${body}<footer><span>All demo music is procedurally synthesized and original.</span><span>Audio truth before audio swagger.</span></footer></main>`;
-  const canvas=document.querySelector('#waveform');
-  if(canvas){waveform=new Waveform(canvas);waveform.setProgress(0);}
-  bind();
+  app.innerHTML = renderApp(state, demoEpisode, { profile, isNewBest });
+
+  const canvas = document.querySelector('#waveform');
+  if (canvas) {
+    waveform = new Waveform(canvas);
+    waveform.setProgress(0);
+  } else {
+    waveform = undefined;
+  }
+
+  if (actionType) focusAfter(actionType);
 }
 
-function bind(){
-  document.querySelector('[data-action="play"]')?.addEventListener('click',playCurrentReveal);
-  document.querySelector('[data-action="more"]')?.addEventListener('click',()=>dispatch({type:'MORE_AUDIO'}));
-  document.querySelector('[data-action="next"]')?.addEventListener('click',()=>dispatch({type:'NEXT_CLUE'}));
-  document.querySelector('[data-action="restart"]')?.addEventListener('click',()=>dispatch({type:'RESTART'}));
-  document.querySelector('#answer-form')?.addEventListener('submit',event=>{event.preventDefault();const answer=new FormData(event.currentTarget).get('answer');if(String(answer).trim())dispatch({type:'SUBMIT_ANSWER',answer});});
+function dispatch(action) {
+  const previous = state;
+  const next = reduceRound(state, action, demoEpisode);
+  if (next === previous) return false;
+
+  state = next;
+  if (state.phase === ROUND_PHASES.COMPLETE && previous.phase !== ROUND_PHASES.COMPLETE) {
+    if (state.players.length === 1) {
+      const previousBest = profile.bestScore;
+      profile = profileStore.recordCompletedScore(state.score);
+      isNewBest = state.score > previousBest;
+    }
+  }
+  if (action.type === 'RESTART') isNewBest = false;
+
+  emit(action.type.toLowerCase(), { action, previous });
+  render(action.type);
+  return true;
 }
 
-window.addEventListener('keydown',event=>{if(event.repeat)return;const player=playerForKey(state.players,event.key);if(player){dispatch({type:'BUZZ',playerId:player.id});document.querySelector('#answer')?.focus();}});
+async function playCurrentReveal() {
+  if (!dispatch({ type: 'PLAY_REVEAL' })) return;
+
+  const clue = demoEpisode.clues[state.clueIndex];
+  const reveal = clue.reveals[state.revealIndex];
+  const token = ++playbackToken;
+  waveform?.animate(reveal.duration * 1000);
+
+  try {
+    await audio.play(clue, reveal);
+    if (token !== playbackToken) return;
+    dispatch({ type: 'REVEAL_FINISHED' });
+  } catch (error) {
+    if (token !== playbackToken) return;
+    const message = error instanceof Error ? error.message : 'Unknown playback error';
+    emit('audio_error', { error: message, clueId: clue.id, revealIndex: state.revealIndex });
+    dispatch({ type: 'AUDIO_FAILED', message });
+  }
+}
+
+function stopPlayback() {
+  playbackToken += 1;
+  audio.stop();
+}
+
+app.addEventListener('click', event => {
+  const control = event.target.closest('[data-action]');
+  if (!control || control.disabled) return;
+
+  switch (control.dataset.action) {
+    case 'play':
+      playCurrentReveal();
+      break;
+    case 'more':
+      dispatch({ type: 'MORE_AUDIO' });
+      break;
+    case 'give-up':
+      dispatch({ type: 'GIVE_UP' });
+      break;
+    case 'pass':
+      dispatch({ type: 'PASS' });
+      break;
+    case 'next':
+      stopPlayback();
+      dispatch({ type: 'NEXT_CLUE' });
+      break;
+    case 'restart':
+      stopPlayback();
+      dispatch({ type: 'RESTART' });
+      break;
+    default:
+      break;
+  }
+});
+
+app.addEventListener('submit', event => {
+  if (event.target.id !== 'answer-form') return;
+  event.preventDefault();
+  const answer = new FormData(event.target).get('answer');
+  if (String(answer).trim()) dispatch({ type: 'SUBMIT_ANSWER', answer });
+});
+
+window.addEventListener('keydown', event => {
+  const target = event.target;
+  const isTyping = target instanceof window.HTMLInputElement
+    || target instanceof window.HTMLTextAreaElement
+    || target instanceof window.HTMLSelectElement
+    || target?.isContentEditable;
+  if (event.repeat || event.isComposing || event.altKey || event.ctrlKey || event.metaKey || isTyping) return;
+  if (state.phase !== ROUND_PHASES.ANSWERING || state.activePlayerId) return;
+
+  const player = playerForKey(state.players, event.key);
+  if (player && dispatch({ type: 'BUZZ', playerId: player.id })) event.preventDefault();
+});
+
+window.addEventListener('pagehide', stopPlayback);
 render();

--- a/src/modes/needle-drop/presentation/Waveform.js
+++ b/src/modes/needle-drop/presentation/Waveform.js
@@ -1,7 +1,62 @@
 export class Waveform {
-  constructor(canvas) { this.canvas=canvas; this.context=canvas.getContext('2d'); this.progress=0; this.frame=null; this.resizeObserver=new window.ResizeObserver(()=>this.draw()); this.resizeObserver.observe(canvas); }
-  setProgress(progress) { this.progress=Math.max(0,Math.min(1,progress)); this.draw(); }
-  animate(durationMs) { cancelAnimationFrame(this.frame); const start=performance.now(); const tick=now=>{ this.setProgress((now-start)/durationMs); if(this.progress<1)this.frame=requestAnimationFrame(tick); }; this.frame=requestAnimationFrame(tick); }
-  draw() { const ratio=window.devicePixelRatio||1,width=this.canvas.clientWidth,height=this.canvas.clientHeight; this.canvas.width=width*ratio; this.canvas.height=height*ratio; const ctx=this.context; ctx.scale(ratio,ratio); ctx.clearRect(0,0,width,height); ctx.lineWidth=2; for(let x=0;x<width;x+=4){const envelope=.25+.75*Math.sin(Math.PI*x/width)**1.6; const amplitude=(Math.sin(x*.17)+.5*Math.sin(x*.53)+.2*Math.sin(x*1.7))*height*.18*envelope; ctx.strokeStyle=x/width<=this.progress?'#00f0d0':'rgba(255,255,255,.16)';ctx.beginPath();ctx.moveTo(x,height/2-amplitude);ctx.lineTo(x,height/2+amplitude);ctx.stroke();} }
-  destroy(){cancelAnimationFrame(this.frame);this.resizeObserver.disconnect();}
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.context = canvas.getContext('2d');
+    this.progress = 0;
+    this.frame = null;
+    this.draw = this.draw.bind(this);
+    this.resizeObserver = window.ResizeObserver ? new window.ResizeObserver(this.draw) : null;
+    this.resizeObserver?.observe(canvas);
+    if (!this.resizeObserver) window.addEventListener('resize', this.draw);
+  }
+
+  setProgress(progress) {
+    this.progress = Math.max(0, Math.min(1, progress));
+    this.draw();
+  }
+
+  animate(durationMs) {
+    cancelAnimationFrame(this.frame);
+    const start = performance.now();
+    const tick = now => {
+      this.setProgress((now - start) / durationMs);
+      if (this.progress < 1) this.frame = requestAnimationFrame(tick);
+    };
+    this.frame = requestAnimationFrame(tick);
+  }
+
+  draw() {
+    const ratio = window.devicePixelRatio || 1;
+    const width = this.canvas.clientWidth;
+    const height = this.canvas.clientHeight;
+    const accent = window.getComputedStyle(this.canvas)
+      .getPropertyValue('--accent-2')
+      .trim() || '#00f0d0';
+    this.canvas.width = width * ratio;
+    this.canvas.height = height * ratio;
+    const context = this.context;
+    context.scale(ratio, ratio);
+    context.clearRect(0, 0, width, height);
+    context.lineWidth = 2;
+
+    for (let x = 0; x < width; x += 4) {
+      const envelope = 0.25 + 0.75 * Math.sin(Math.PI * x / width) ** 1.6;
+      const amplitude = (
+        Math.sin(x * 0.17)
+        + 0.5 * Math.sin(x * 0.53)
+        + 0.2 * Math.sin(x * 1.7)
+      ) * height * 0.18 * envelope;
+      context.strokeStyle = x / width <= this.progress ? accent : 'rgba(255, 255, 255, 0.16)';
+      context.beginPath();
+      context.moveTo(x, height / 2 - amplitude);
+      context.lineTo(x, height / 2 + amplitude);
+      context.stroke();
+    }
+  }
+
+  destroy() {
+    cancelAnimationFrame(this.frame);
+    this.resizeObserver?.disconnect();
+    if (!this.resizeObserver) window.removeEventListener('resize', this.draw);
+  }
 }

--- a/src/modes/needle-drop/presentation/markup.js
+++ b/src/modes/needle-drop/presentation/markup.js
@@ -1,0 +1,230 @@
+import { rankPlayers } from '../core/party.js';
+import { ROUND_PHASES } from '../core/round.js';
+
+export function escapeHtml(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+const formatPoints = value => Number(value || 0).toLocaleString();
+
+function playerCountMarkup(count) {
+  return `<nav class="player-count" aria-label="Player count">
+    ${[1, 2, 3, 4].map(value => `<a href="?players=${value}" ${value === count ? 'aria-current="page"' : ''}>${value}P</a>`).join('')}
+  </nav>`;
+}
+
+function rulesMarkup(isParty) {
+  return `<details class="rules">
+    <summary>How to play <span>three steps, zero liner notes required</span></summary>
+    <ol>
+      <li><strong>Listen.</strong> Start with a ruthless 0.25-second fragment.</li>
+      <li><strong>${isParty ? 'Buzz.' : 'Name it.'}</strong> ${isParty ? 'First eligible number key owns the mic.' : 'Lock a title after the clip ends.'}</li>
+      <li><strong>Choose.</strong> Guess, replay free, or buy more audio for fewer points.</li>
+    </ol>
+  </details>`;
+}
+
+function playersMarkup(state) {
+  return `<section class="players" aria-label="Players">
+    ${state.players.map(player => {
+      const isActive = state.activePlayerId === player.id;
+      const isBlocked = state.blockedPlayerIds.includes(player.id);
+      const classes = [isActive ? 'is-active' : '', isBlocked ? 'is-blocked' : '']
+        .filter(Boolean)
+        .join(' ');
+      const status = isActive ? 'ON MIC' : (isBlocked ? 'LOCKED THIS CLIP' : '');
+
+      return `<article class="${classes}" data-player-id="${player.id}" style="--player:${player.color}" aria-label="${escapeHtml(player.name)}, ${formatPoints(player.score)} points${status ? `, ${status.toLowerCase()}` : ''}">
+        <kbd aria-label="Buzz key ${player.buzzKey}">${player.buzzKey}</kbd>
+        <span class="players__identity"><strong>${escapeHtml(player.name)}</strong>${status ? `<small>${status}</small>` : ''}</span>
+        <span class="players__score">${formatPoints(player.score)}</span>
+      </article>`;
+    }).join('')}
+  </section>`;
+}
+
+function hostMessage(state, clue) {
+  if (state.audioError) return `Audio hiccup: ${state.audioError}`;
+  if (state.phase === ROUND_PHASES.READY) {
+    return state.revealIndex === 0
+      ? `Needle armed. Hear ${clue.reveals[0].duration} seconds, then make history or a small mistake.`
+      : `${clue.reveals[state.revealIndex].duration}-second reveal ready. The points have become less emotionally available.`;
+  }
+  if (state.phase === ROUND_PHASES.LISTENING) return 'Ears up. Shazam has been asked to leave the building.';
+  if (state.phase !== ROUND_PHASES.ANSWERING) return '';
+
+  const activePlayer = state.players.find(player => player.id === state.activePlayerId);
+  if (activePlayer) return `${activePlayer.name} owns the mic. Lock an answer.`;
+
+  const allBlocked = state.blockedPlayerIds.length === state.players.length;
+  if (allBlocked) {
+    return state.revealIndex < clue.reveals.length - 1
+      ? 'Nobody got it. Buy more audio to put every player back in the hunt.'
+      : 'The full alibi fooled the room. Reveal the answer when dignity permits.';
+  }
+  if (state.players.length > 1) return 'Buzzers open. First eligible number key owns the mic.';
+  return 'Name that suspicious noise. Spelling is judged by humans, which is already too much power.';
+}
+
+function missMarkup(state) {
+  if (!state.lastAttempt || state.lastAttempt.accepted || state.phase === ROUND_PHASES.RESOLVED) return '';
+  const player = state.players.find(item => item.id === state.lastAttempt.playerId);
+  const subject = player?.name || 'The room';
+  if (state.lastAttempt.passed) {
+    return `<p class="miss-call" role="status"><strong>${escapeHtml(subject)}</strong> passed the mic. Steal window open.</p>`;
+  }
+  const answer = state.lastAttempt.answer ? ` “${escapeHtml(state.lastAttempt.answer)}”` : '';
+
+  return `<p class="miss-call" role="status"><strong>${escapeHtml(subject)}:</strong>${answer} is not on the label. Steal window open.</p>`;
+}
+
+function lineageMarkup(clue) {
+  return `<div class="lineage" aria-label="Sample lineage">
+    <article>
+      <span>ORIGINAL SOURCE</span>
+      <strong>${escapeHtml(clue.source.title)}</strong>
+      <small>${escapeHtml(clue.source.artist)} · ${clue.source.year}</small>
+    </article>
+    <div class="lineage__arrow" aria-hidden="true">➜<small>${clue.transformation.map(escapeHtml).join(' · ')}</small></div>
+    <article>
+      <span>THE FLIP</span>
+      <strong>${escapeHtml(clue.title)}</strong>
+      <small>${escapeHtml(clue.artist)}</small>
+    </article>
+  </div>
+  <blockquote class="liner-note">“${escapeHtml(clue.linerNote)}”</blockquote>`;
+}
+
+function resultMarkup(state, episode, clue) {
+  const accepted = state.result.accepted;
+  const player = state.players.find(item => item.id === state.result.playerId);
+  const attemptCount = state.attempts.filter(attempt => attempt.clueId === clue.id && !attempt.gaveUp).length;
+  const eyebrow = accepted
+    ? `CORRECT${player && state.players.length > 1 ? ` · ${player.name.toUpperCase()} SCORES` : ''}`
+    : 'THE RECORD DISAGREES';
+  const scoreLine = accepted
+    ? `+${formatPoints(state.result.points)} points`
+    : `0 points · ${attemptCount ? `${attemptCount} brave ${attemptCount === 1 ? 'guess' : 'guesses'}` : 'strategic surrender'}`;
+
+  return `<section class="clue-card clue-card--result">
+    <section class="result ${accepted ? 'result--correct' : 'result--wrong'}" role="status" aria-live="polite">
+      <p class="eyebrow">${escapeHtml(eyebrow)}</p>
+      <h2 id="result-heading" tabindex="-1">${escapeHtml(clue.title)}</h2>
+      <p>${escapeHtml(clue.artist)}</p>
+      <strong>${escapeHtml(scoreLine)}</strong>
+    </section>
+    ${lineageMarkup(clue)}
+    <button type="button" class="next" data-action="next">${state.clueIndex === episode.clues.length - 1 ? 'Close the crate' : 'Next record'} →</button>
+  </section>`;
+}
+
+function roundMarkup(state, episode, clue, reveal) {
+  if (state.phase === ROUND_PHASES.RESOLVED) return resultMarkup(state, episode, clue);
+
+  const heardCurrentReveal = state.listenedRevealIndex >= state.revealIndex;
+  const activePlayer = state.players.find(player => player.id === state.activePlayerId);
+  const canAnswer = state.phase === ROUND_PHASES.ANSWERING
+    && activePlayer
+    && !state.blockedPlayerIds.includes(activePlayer.id);
+  const canPlay = [ROUND_PHASES.READY, ROUND_PHASES.ANSWERING].includes(state.phase)
+    && !state.activePlayerId;
+  const canBuy = state.phase === ROUND_PHASES.ANSWERING
+    && heardCurrentReveal
+    && !state.activePlayerId
+    && state.revealIndex < clue.reveals.length - 1;
+  const canGiveUp = state.phase === ROUND_PHASES.ANSWERING
+    && state.listenedRevealIndex >= 0
+    && !state.activePlayerId;
+  const nextReveal = clue.reveals[state.revealIndex + 1];
+  const answerLabel = canAnswer
+    ? `${activePlayer.name}'s answer`
+    : (state.phase === ROUND_PHASES.READY ? 'Listen before answering' : 'Buzz to claim the mic');
+  const playLabel = state.phase === ROUND_PHASES.LISTENING
+    ? 'Listening…'
+    : (heardCurrentReveal ? `↻ Replay ${reveal.duration}s` : '▶ Drop the needle');
+
+  return `<section class="clue-card">
+    <div class="clue-card__progress" style="--progress:${((state.clueIndex + 1) / episode.clues.length) * 100}%" aria-hidden="true"></div>
+    <div class="clue-card__meta"><span>TRACK ${state.clueIndex + 1}/${episode.clues.length}</span><span>${escapeHtml(clue.category)}</span></div>
+    <h2>${escapeHtml(clue.prompt)}</h2>
+    <div class="turntable" aria-hidden="true"><div class="record ${state.phase === ROUND_PHASES.LISTENING ? 'record--spinning' : ''}"><i></i></div><div class="tonearm"></div></div>
+    <canvas id="waveform" class="waveform" role="img" aria-label="Stylized audio waveform showing playback progress"></canvas>
+    <div class="reveal-meter" aria-label="Audio reveal ladder">
+      ${clue.reveals.map((item, index) => `<div class="${index === state.revealIndex ? 'is-current' : ''} ${index < state.revealIndex ? 'is-spent' : ''} ${index <= state.listenedRevealIndex ? 'is-heard' : ''}">
+        <span>${escapeHtml(item.label)}</span><strong>${item.duration}s</strong><small>${item.points} pts</small>
+      </div>`).join('')}
+    </div>
+    <p class="host-call ${state.audioError ? 'host-call--error' : ''}" role="status" aria-live="polite">${escapeHtml(hostMessage(state, clue))}</p>
+    ${missMarkup(state)}
+    <form id="answer-form" class="answer">
+      <label for="answer">${escapeHtml(answerLabel)}</label>
+      <div>
+        <input id="answer" name="answer" autocomplete="off" placeholder="Name that suspicious noise…" ${canAnswer ? '' : 'disabled'} />
+        <button type="submit" ${canAnswer ? '' : 'disabled'}>Lock it</button>
+      </div>
+      ${state.players.length > 1 ? `<button type="button" class="answer__pass" data-action="pass" ${canAnswer ? '' : 'disabled'}>Pass mic · open the steal</button>` : ''}
+    </form>
+    <div class="controls">
+      <button type="button" class="button--needle" data-action="play" ${canPlay ? '' : 'disabled'}>${escapeHtml(playLabel)}</button>
+      <button type="button" data-action="more" ${canBuy ? '' : 'disabled'}>Buy more audio <small>${nextReveal ? `−${reveal.points - nextReveal.points} potential` : 'full clip reached'}</small></button>
+      <button type="button" class="button--quiet" data-action="give-up" ${canGiveUp ? '' : 'disabled'}>Reveal answer <small>the crate keeps no secrets</small></button>
+    </div>
+  </section>`;
+}
+
+function finaleMarkup(state, episode, profile, isNewBest) {
+  const ranked = rankPlayers(state.players);
+  const topScore = ranked[0]?.score || 0;
+  const winners = ranked.filter(player => player.score === topScore);
+  const title = state.players.length === 1
+    ? `${state.correct}/${episode.clues.length} identified`
+    : (winners.length > 1 ? 'A crate-sharing tie' : `${winners[0].name} wins the crate`);
+
+  return `<section class="finale">
+    <p class="eyebrow">CRATE CLOSED</p>
+    <h2 id="finale-heading" tabindex="-1">${escapeHtml(title)}</h2>
+    <p>${formatPoints(state.score)} room points. The waveform has declined to comment.</p>
+    ${state.players.length === 1 ? `<p class="personal-best ${isNewBest ? 'is-new' : ''}">${isNewBest ? 'NEW PERSONAL BEST' : 'PERSONAL BEST'} <strong>${formatPoints(profile.bestScore)}</strong></p>` : ''}
+    <ol class="standings" aria-label="Final standings">
+      ${ranked.map((player, index) => `<li style="--player:${player.color}"><span>${index + 1}</span><strong>${escapeHtml(player.name)}</strong><small>${player.correct} correct</small><b>${formatPoints(player.score)}</b></li>`).join('')}
+    </ol>
+    <button type="button" data-action="restart">Spin it again</button>
+  </section>`;
+}
+
+export function renderApp(state, episode, { profile, isNewBest = false } = {}) {
+  const clue = episode.clues[state.clueIndex];
+  const reveal = clue?.reveals[state.revealIndex];
+  const complete = state.phase === ROUND_PHASES.COMPLETE;
+  const isParty = state.players.length > 1;
+  const ranked = rankPlayers(state.players);
+  const secondaryMetric = isParty
+    ? { label: 'LEAD', value: formatPoints(ranked[0]?.score) }
+    : { label: 'STREAK', value: state.players[0]?.streak || 0 };
+  const body = complete
+    ? finaleMarkup(state, episode, profile, isNewBest)
+    : roundMarkup(state, episode, clue, reveal);
+
+  return `<main id="game" class="stage" data-phase="${state.phase}" data-reveal-index="${state.revealIndex}" style="--accent:${clue?.palette?.[0] || '#ff3f81'};--accent-2:${clue?.palette?.[1] || '#00d7d7'}">
+    <header class="show-header">
+      <a href="./" class="show-header__universe">JEO<span>PARODY</span> / MUSIC DISTRICT</a>
+      <div class="show-header__score"><span>${isParty ? 'ROOM TOTAL' : 'SCORE'}</span><strong>${formatPoints(state.score)}</strong></div>
+      <div class="show-header__streak"><span>${secondaryMetric.label}</span><strong>${secondaryMetric.value}</strong></div>
+    </header>
+    <section class="marquee">
+      <span>PROJECT CRATE EXPECTATIONS</span>
+      <h1>NEEDLE DROP</h1>
+      <p>Musical archaeology conducted at an unsafe volume.</p>
+      ${playerCountMarkup(state.players.length)}
+      ${rulesMarkup(isParty)}
+    </section>
+    ${playersMarkup(state)}
+    ${body}
+    <footer><span>All demo music is procedurally synthesized and original.</span><span>Audio truth before audio swagger.</span></footer>
+  </main>`;
+}

--- a/src/modes/needle-drop/services/audioRuntime.js
+++ b/src/modes/needle-drop/services/audioRuntime.js
@@ -2,7 +2,21 @@ import { DecodedBufferAudio } from './decodedBufferAudio.js';
 import { SynthAudio } from './synthAudio.js';
 
 export class AudioRuntime {
-  constructor({synth=new SynthAudio(),decoded=new DecodedBufferAudio()}={}) { this.synth=synth; this.decoded=decoded; }
-  stop(){this.synth.stop();this.decoded.stop();}
-  play(clue,reveal){if(clue.audio?.kind==='asset')return this.decoded.play(clue.audio,reveal);if(clue.audio?.kind==='synth')return this.synth.play(clue.audio.sequence,reveal.duration);throw new Error(`Unsupported audio kind for clue ${clue.id}`);}
+  constructor({ synth = new SynthAudio(), decoded = new DecodedBufferAudio() } = {}) {
+    this.synth = synth;
+    this.decoded = decoded;
+  }
+
+  stop() {
+    this.synth.stop();
+    this.decoded.stop();
+  }
+
+  play(clue, reveal) {
+    if (clue.audio?.kind === 'asset') return this.decoded.play(clue.audio, reveal);
+    if (clue.audio?.kind === 'synth') {
+      return this.synth.play(clue.audio.sequence, reveal.duration);
+    }
+    throw new Error(`Unsupported audio kind for clue ${clue.id}`);
+  }
 }

--- a/src/modes/needle-drop/services/profileStore.js
+++ b/src/modes/needle-drop/services/profileStore.js
@@ -1,0 +1,46 @@
+const STORAGE_KEY = 'jeoparody.needle-drop.profile.v1';
+
+const EMPTY_PROFILE = Object.freeze({
+  bestScore: 0,
+  completedRuns: 0,
+});
+
+export class ProfileStore {
+  constructor(storage) {
+    try {
+      this.storage = storage || window.localStorage;
+    } catch {
+      this.storage = null;
+    }
+  }
+
+  read() {
+    try {
+      const value = JSON.parse(this.storage?.getItem(STORAGE_KEY) || 'null');
+      if (!value || typeof value !== 'object') return { ...EMPTY_PROFILE };
+
+      return {
+        bestScore: Math.max(0, Number(value.bestScore) || 0),
+        completedRuns: Math.max(0, Number(value.completedRuns) || 0),
+      };
+    } catch {
+      return { ...EMPTY_PROFILE };
+    }
+  }
+
+  recordCompletedScore(score) {
+    const current = this.read();
+    const next = {
+      bestScore: Math.max(current.bestScore, Math.max(0, Number(score) || 0)),
+      completedRuns: current.completedRuns + 1,
+    };
+
+    try {
+      this.storage?.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Storage can be unavailable in private or embedded contexts. The game remains playable.
+    }
+
+    return next;
+  }
+}

--- a/src/modes/needle-drop/services/synthAudio.js
+++ b/src/modes/needle-drop/services/synthAudio.js
@@ -1,11 +1,72 @@
 export class SynthAudio {
-  constructor(contextFactory = () => new window.AudioContext()) { this.contextFactory=contextFactory; this.context=null; this.activeNodes=new Set(); }
-  getContext() { this.context ||= this.contextFactory(); return this.context; }
-  stop() { for (const node of this.activeNodes) { try { node.stop(); } catch { /* already stopped */ } } this.activeNodes.clear(); }
+  constructor(contextFactory = () => {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) throw new Error('Web Audio is unavailable in this browser.');
+    return new AudioContextClass();
+  }) {
+    this.contextFactory = contextFactory;
+    this.context = null;
+    this.activeNodes = new Set();
+    this.completionTimer = null;
+    this.completionResolve = null;
+  }
+
+  getContext() {
+    if (!this.context || this.context.state === 'closed') this.context = this.contextFactory();
+    return this.context;
+  }
+
+  stop() {
+    for (const node of this.activeNodes) {
+      try {
+        node.stop();
+      } catch {
+        // The oscillator already stopped itself.
+      }
+    }
+    this.activeNodes.clear();
+    if (this.completionTimer) clearTimeout(this.completionTimer);
+    this.completionTimer = null;
+    this.completionResolve?.();
+    this.completionResolve = null;
+  }
+
   async play(sequence, windowSeconds) {
-    this.stop(); const context=this.getContext(); if (context.state === 'suspended') await context.resume();
-    const start=context.currentTime+.04; const end=start+windowSeconds; let cursor=start;
-    while (cursor<end) for (const step of sequence) { if (cursor>=end) break; const duration=Math.min(step.duration,end-cursor); const oscillator=context.createOscillator(); const gain=context.createGain(); oscillator.type=step.type; oscillator.frequency.setValueAtTime(step.frequency,cursor); gain.gain.setValueAtTime(.0001,cursor); gain.gain.exponentialRampToValueAtTime(step.gain,cursor+Math.min(.015,duration/3)); gain.gain.exponentialRampToValueAtTime(.0001,cursor+duration); oscillator.connect(gain).connect(context.destination); oscillator.start(cursor); oscillator.stop(cursor+duration); this.activeNodes.add(oscillator); oscillator.onended=()=>this.activeNodes.delete(oscillator); cursor+=step.duration; }
-    return new Promise(resolve=>{ setTimeout(resolve,windowSeconds*1000+50); });
+    this.stop();
+    const context = this.getContext();
+    if (context.state === 'suspended') await context.resume();
+
+    const start = context.currentTime + 0.04;
+    const end = start + windowSeconds;
+    let cursor = start;
+
+    while (cursor < end) {
+      for (const step of sequence) {
+        if (cursor >= end) break;
+        const duration = Math.min(step.duration, end - cursor);
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        oscillator.type = step.type;
+        oscillator.frequency.setValueAtTime(step.frequency, cursor);
+        gain.gain.setValueAtTime(0.0001, cursor);
+        gain.gain.exponentialRampToValueAtTime(step.gain, cursor + Math.min(0.015, duration / 3));
+        gain.gain.exponentialRampToValueAtTime(0.0001, cursor + duration);
+        oscillator.connect(gain).connect(context.destination);
+        oscillator.start(cursor);
+        oscillator.stop(cursor + duration);
+        this.activeNodes.add(oscillator);
+        oscillator.onended = () => this.activeNodes.delete(oscillator);
+        cursor += step.duration;
+      }
+    }
+
+    return new Promise(resolve => {
+      this.completionResolve = resolve;
+      this.completionTimer = setTimeout(() => {
+        this.completionTimer = null;
+        this.completionResolve = null;
+        resolve();
+      }, windowSeconds * 1000 + 50);
+    });
   }
 }

--- a/src/modes/needle-drop/styles.css
+++ b/src/modes/needle-drop/styles.css
@@ -1,9 +1,830 @@
-:root{color-scheme:dark;font-family:Inter,Arial,sans-serif;background:#090b12;color:#f8f0df}*{box-sizing:border-box}body{margin:0;min-width:320px;background:radial-gradient(circle at 50% -10%,#262043 0,#090b12 46%)}button,input{font:inherit}button{cursor:pointer}button:disabled{cursor:not-allowed;opacity:.36}.skip-link{position:fixed;left:1rem;top:-4rem;z-index:10;background:#fff;color:#000;padding:.75rem}.skip-link:focus{top:1rem}.stage{min-height:100vh;overflow:hidden;position:relative}.stage::before{content:'';position:fixed;inset:0;pointer-events:none;opacity:.08;background-image:repeating-linear-gradient(0deg,transparent 0 3px,#fff 4px)}.show-header{height:68px;display:flex;align-items:stretch;border-bottom:1px solid #ffffff20;background:#090b12cc;position:relative;z-index:2}.show-header__universe{color:#fff;text-decoration:none;font:800 .78rem ui-monospace,monospace;letter-spacing:.1em;display:flex;align-items:center;padding:0 2rem;margin-right:auto}.show-header__universe span{color:var(--accent)}.show-header__score,.show-header__streak{min-width:130px;padding:.75rem 1.5rem;border-left:1px solid #ffffff20;display:grid}.show-header span{font:500 .65rem ui-monospace,monospace;letter-spacing:.13em;color:#a8a5b2}.show-header strong{font:800 1.25rem ui-monospace,monospace;color:#fff}.marquee{text-align:center;padding:2.7rem 1rem 1.5rem}.marquee>span,.eyebrow{color:var(--accent-2);font:500 .68rem ui-monospace,monospace;letter-spacing:.2em}.marquee h1{margin:.2rem 0;font:900 clamp(3rem,9vw,7rem)/.9 Impact,'Arial Black',sans-serif;letter-spacing:-.03em;transform:skew(-3deg);text-shadow:6px 6px 0 var(--accent),12px 12px 0 #000}.marquee p{color:#aaa6b3;margin:1.2rem 0 0}.clue-card,.finale{width:min(920px,calc(100% - 2rem));margin:0 auto 3rem;padding:clamp(1.2rem,4vw,2.5rem);border:1px solid #ffffff27;background:linear-gradient(145deg,#171924e8,#0d0f17e8);border-radius:18px;box-shadow:0 28px 80px #0009,inset 0 1px #fff1;position:relative}.clue-card__meta{display:flex;justify-content:space-between;color:var(--accent-2);font:500 .7rem ui-monospace,monospace;letter-spacing:.08em}.clue-card h2{font:800 clamp(1.35rem,4vw,2.2rem)/1.1 Inter,Arial,sans-serif;max-width:680px;margin:1rem 0 1.4rem}.turntable{position:absolute;width:155px;height:120px;right:2.2rem;top:4.8rem;opacity:.92}.record{width:108px;height:108px;border-radius:50%;background:repeating-radial-gradient(circle,#070707 0 4px,#27272b 5px 6px);box-shadow:0 0 0 2px #000,0 10px 30px #000;display:grid;place-items:center}.record i{width:34px;height:34px;border-radius:50%;background:var(--accent);border:3px solid #151515}.record--spinning{animation:spin .8s linear infinite}.tonearm{position:absolute;width:72px;height:7px;background:#c3c1c7;right:0;top:18px;transform:rotate(55deg);transform-origin:right center;border-radius:8px}
+:root {
+  color-scheme: dark;
+  font-family: Inter, Arial, sans-serif;
+  background: #090b12;
+  color: #f8f0df;
+}
 
-@keyframes spin{to{transform:rotate(360deg)}}.waveform{width:calc(100% - 180px);height:116px;display:block;margin:1.6rem 0}.reveal-meter{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}.reveal-meter div{padding:.75rem;border:1px solid #ffffff17;background:#ffffff07;display:grid;gap:.22rem}.reveal-meter .is-current{border-color:var(--accent);box-shadow:inset 0 -3px var(--accent)}.reveal-meter .is-spent{opacity:.36}.reveal-meter span{font:500 .62rem ui-monospace,monospace;color:#aaa6b3;text-transform:uppercase}.reveal-meter strong{font:800 1.15rem ui-monospace,monospace}.reveal-meter small{color:var(--accent-2)}.answer{margin-top:1.4rem}.answer label{display:block;font:500 .68rem ui-monospace,monospace;letter-spacing:.12em;text-transform:uppercase;margin-bottom:.5rem;color:#aaa6b3}.answer>div{display:flex}.answer input{width:100%;min-width:0;background:#080910;border:1px solid #ffffff28;color:#fff;padding:1rem;border-radius:9px 0 0 9px;outline:none}.answer input:focus{border-color:var(--accent-2)}.answer button,.controls button,.next,.finale button{border:0;background:var(--accent-2);color:#06100f;font-weight:800;padding:0 1.4rem;border-radius:0 9px 9px 0}.controls{display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:.75rem}.controls button{border-radius:9px;min-height:58px;background:#242633;color:#fff;border:1px solid #ffffff18}.controls .button--needle{background:var(--accent);color:#fff;border:0}.controls small{display:block;color:#aaa6b3;font-weight:400}.result{border-left:5px solid var(--accent-2);margin-top:1.5rem;padding:1rem 1.25rem;background:#ffffff08}.result--wrong{border-color:#ff5b69}.result h3{font:900 2rem Impact,'Arial Black',sans-serif;margin:.3rem 0}.result p{margin:.2rem 0;color:#aaa6b3}.result>strong{display:block;color:var(--accent-2);margin-top:.8rem}.lineage{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:1rem;margin:1rem 0}.lineage article{padding:1rem;background:#090b12;border:1px solid #ffffff16;display:grid;gap:.35rem}.lineage span,.lineage small{color:#aaa6b3;font:500 .63rem ui-monospace,monospace}.lineage__arrow{text-align:center;color:var(--accent-2);font-size:1.8rem}.lineage__arrow small{display:block;max-width:180px;font-size:.6rem;color:#aaa6b3}.next,.finale button{display:block;padding:1rem 1.6rem;border-radius:9px;margin-left:auto}.finale{text-align:center;padding:5rem 2rem}.finale h2{font:900 clamp(2rem,7vw,4.5rem) Impact,'Arial Black',sans-serif;margin:.6rem 0}.finale button{margin:2rem auto 0}footer{display:flex;justify-content:space-between;width:min(920px,calc(100% - 2rem));margin:0 auto;padding:0 0 2rem;color:#74717d;font:400 .65rem ui-monospace,monospace}
+* {
+  box-sizing: border-box;
+}
 
-@media(width <=700px){.show-header__universe{padding:0 1rem}.show-header__streak{display:none}.show-header__score{min-width:100px;padding:.75rem}.turntable{display:none}.waveform{width:100%}.reveal-meter{grid-template-columns:1fr 1fr}.lineage{grid-template-columns:1fr}.lineage__arrow{transform:rotate(90deg)}footer{display:grid;gap:.4rem}.clue-card__meta{gap:1rem}.marquee h1{text-shadow:4px 4px 0 var(--accent),8px 8px #000}.controls{grid-template-columns:1fr}}
+html {
+  scroll-behavior: smooth;
+}
 
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.001ms!important;scroll-behavior:auto!important}}
+body {
+  margin: 0;
+  min-width: 320px;
+  background: radial-gradient(circle at 50% -10%, #262043 0, #090b12 46%);
+}
 
-.player-count{display:flex;justify-content:center;gap:.4rem;margin-top:.9rem}.player-count a{color:#aaa6b3;text-decoration:none;font:700 .68rem ui-monospace,monospace;border:1px solid #ffffff24;border-radius:999px;padding:.4rem .65rem}.player-count a:hover,.player-count a:focus{color:#fff;border-color:var(--accent-2)}.players{width:min(920px,calc(100% - 2rem));margin:0 auto 1rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:.55rem}.players article{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:.55rem;padding:.65rem .8rem;border:1px solid #ffffff19;border-radius:9px;background:#11131dcc;color:#aaa6b3}.players article.is-active{border-color:var(--player);box-shadow:inset 0 -3px var(--player);color:#fff}.players kbd{display:grid;place-items:center;width:1.7rem;height:1.7rem;border-radius:5px;background:var(--player);color:#080910;font:900 .8rem ui-monospace,monospace}.players span{font:600 .7rem ui-monospace,monospace}.players strong{font:800 .8rem ui-monospace,monospace}
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  transition: transform 140ms ease, filter 140ms ease, border-color 140ms ease;
+}
+
+button:not(:disabled):hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.36;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+summary:focus-visible,
+[tabindex="-1"]:focus-visible {
+  outline: 3px solid var(--accent-2, #00d7d7);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: fixed;
+  top: -4rem;
+  left: 1rem;
+  z-index: 10;
+  padding: 0.75rem;
+  background: #fff;
+  color: #000;
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+.stage {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.stage::before {
+  position: fixed;
+  inset: 0;
+  content: "";
+  pointer-events: none;
+  opacity: 0.08;
+  background-image: repeating-linear-gradient(0deg, transparent 0 3px, #fff 4px);
+}
+
+.show-header {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: stretch;
+  height: 68px;
+  border-bottom: 1px solid #ffffff20;
+  background: #090b12e8;
+  backdrop-filter: blur(12px);
+}
+
+.show-header__universe {
+  display: flex;
+  align-items: center;
+  margin-right: auto;
+  padding: 0 2rem;
+  color: #fff;
+  font: 800 0.78rem ui-monospace, monospace;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+}
+
+.show-header__universe span {
+  color: var(--accent);
+}
+
+.show-header__score,
+.show-header__streak {
+  display: grid;
+  min-width: 130px;
+  padding: 0.75rem 1.5rem;
+  border-left: 1px solid #ffffff20;
+}
+
+.show-header span {
+  color: #a8a5b2;
+  font: 500 0.65rem ui-monospace, monospace;
+  letter-spacing: 0.13em;
+}
+
+.show-header strong {
+  color: #fff;
+  font: 800 1.25rem ui-monospace, monospace;
+}
+
+.marquee {
+  padding: 2.7rem 1rem 1.15rem;
+  text-align: center;
+}
+
+.marquee > span,
+.eyebrow {
+  color: var(--accent-2);
+  font: 500 0.68rem ui-monospace, monospace;
+  letter-spacing: 0.2em;
+}
+
+.marquee h1 {
+  margin: 0.2rem 0;
+  color: #fff8df;
+  font: 900 clamp(3rem, 9vw, 7rem) / 0.9 Impact, "Arial Black", sans-serif;
+  letter-spacing: -0.03em;
+  text-shadow: 6px 6px 0 var(--accent), 12px 12px 0 #000;
+  transform: skew(-3deg);
+}
+
+.marquee > p {
+  margin: 1.2rem 0 0;
+  color: #aaa6b3;
+}
+
+.player-count {
+  display: flex;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+}
+
+.player-count a {
+  padding: 0.4rem 0.65rem;
+  border: 1px solid #ffffff24;
+  border-radius: 999px;
+  color: #aaa6b3;
+  font: 700 0.68rem ui-monospace, monospace;
+  text-decoration: none;
+}
+
+.player-count a:hover,
+.player-count a:focus,
+.player-count a[aria-current="page"] {
+  border-color: var(--accent-2);
+  color: #fff;
+}
+
+.player-count a[aria-current="page"] {
+  background: var(--accent-2);
+  color: #07110f;
+}
+
+.rules {
+  width: min(620px, 100%);
+  margin: 0.9rem auto 0;
+  border: 1px solid #ffffff14;
+  border-radius: 10px;
+  background: #090b1280;
+  text-align: left;
+}
+
+.rules summary {
+  padding: 0.65rem 0.9rem;
+  color: #e8e1d4;
+  font: 700 0.72rem ui-monospace, monospace;
+  cursor: pointer;
+}
+
+.rules summary span {
+  margin-left: 0.35rem;
+  color: #777482;
+  font-weight: 400;
+}
+
+.rules ol {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 0;
+  padding: 0.4rem 1.2rem 1rem 2.2rem;
+  color: #aaa6b3;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.rules strong {
+  display: block;
+  color: #fff;
+}
+
+.players {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 0.55rem;
+  width: min(920px, calc(100% - 2rem));
+  margin: 0 auto 1rem;
+}
+
+.players article {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 48px;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid #ffffff19;
+  border-radius: 9px;
+  background: #11131dcc;
+  color: #aaa6b3;
+  transition: border-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.players article.is-active {
+  border-color: var(--player);
+  box-shadow: inset 0 -3px var(--player), 0 0 24px color-mix(in srgb, var(--player), transparent 80%);
+  color: #fff;
+}
+
+.players article.is-blocked {
+  opacity: 0.46;
+}
+
+.players kbd {
+  display: grid;
+  place-items: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 5px;
+  background: var(--player);
+  color: #080910;
+  font: 900 0.8rem ui-monospace, monospace;
+}
+
+.players__identity {
+  display: grid;
+  min-width: 0;
+}
+
+.players__identity strong,
+.players__identity small {
+  overflow: hidden;
+  font: 600 0.7rem ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.players__identity small {
+  color: var(--player);
+  font-size: 0.54rem;
+  letter-spacing: 0.08em;
+}
+
+.players__score {
+  color: #fff;
+  font: 800 0.8rem ui-monospace, monospace;
+}
+
+.clue-card,
+.finale {
+  position: relative;
+  width: min(920px, calc(100% - 2rem));
+  margin: 0 auto 3rem;
+  padding: clamp(1.2rem, 4vw, 2.5rem);
+  overflow: hidden;
+  border: 1px solid #ffffff27;
+  border-radius: 18px;
+  background: linear-gradient(145deg, #171924f2, #0d0f17f2);
+  box-shadow: 0 28px 80px #0009, inset 0 1px #fff1;
+}
+
+.clue-card__progress {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 3px;
+  background: #ffffff0d;
+}
+
+.clue-card__progress::after {
+  display: block;
+  width: var(--progress);
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  content: "";
+}
+
+.clue-card__meta {
+  display: flex;
+  justify-content: space-between;
+  color: var(--accent-2);
+  font: 500 0.7rem ui-monospace, monospace;
+  letter-spacing: 0.08em;
+}
+
+.clue-card h2 {
+  max-width: 680px;
+  margin: 1rem 0 1.4rem;
+  font: 800 clamp(1.35rem, 4vw, 2.2rem) / 1.1 Inter, Arial, sans-serif;
+}
+
+.turntable {
+  position: absolute;
+  top: 4.8rem;
+  right: 2.2rem;
+  width: 155px;
+  height: 120px;
+  opacity: 0.92;
+}
+
+.record {
+  display: grid;
+  place-items: center;
+  width: 108px;
+  height: 108px;
+  border-radius: 50%;
+  background: repeating-radial-gradient(circle, #070707 0 4px, #27272b 5px 6px);
+  box-shadow: 0 0 0 2px #000, 0 10px 30px #000;
+}
+
+.record i {
+  width: 34px;
+  height: 34px;
+  border: 3px solid #151515;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.record--spinning {
+  animation: spin 0.8s linear infinite;
+}
+
+.tonearm {
+  position: absolute;
+  top: 18px;
+  right: 0;
+  width: 72px;
+  height: 7px;
+  border-radius: 8px;
+  background: #c3c1c7;
+  transform: rotate(55deg);
+  transform-origin: right center;
+}
+
+.waveform {
+  display: block;
+  width: calc(100% - 180px);
+  height: 116px;
+  margin: 1.6rem 0;
+}
+
+.reveal-meter {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.reveal-meter div {
+  display: grid;
+  gap: 0.22rem;
+  padding: 0.75rem;
+  border: 1px solid #ffffff17;
+  background: #ffffff07;
+}
+
+.reveal-meter .is-current {
+  border-color: var(--accent);
+  box-shadow: inset 0 -3px var(--accent);
+}
+
+.reveal-meter .is-spent {
+  opacity: 0.36;
+}
+
+.reveal-meter .is-heard span::after {
+  margin-left: 0.3rem;
+  color: var(--accent-2);
+  content: "✓";
+}
+
+.reveal-meter span {
+  color: #aaa6b3;
+  font: 500 0.62rem ui-monospace, monospace;
+  text-transform: uppercase;
+}
+
+.reveal-meter strong {
+  font: 800 1.15rem ui-monospace, monospace;
+}
+
+.reveal-meter small {
+  color: var(--accent-2);
+}
+
+.host-call,
+.miss-call {
+  margin: 1rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid var(--accent-2);
+  background: #ffffff08;
+  color: #d2ced7;
+  font: 600 0.72rem / 1.45 ui-monospace, monospace;
+}
+
+.host-call--error,
+.miss-call {
+  border-color: #ff6b78;
+}
+
+.miss-call {
+  margin-top: 0.45rem;
+  color: #ffc6cc;
+}
+
+.answer {
+  margin-top: 1.15rem;
+}
+
+.answer label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #aaa6b3;
+  font: 500 0.68rem ui-monospace, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.answer > div {
+  display: flex;
+}
+
+.answer input {
+  width: 100%;
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid #ffffff28;
+  border-radius: 9px 0 0 9px;
+  outline: none;
+  background: #080910;
+  color: #fff;
+}
+
+.answer input:disabled {
+  color: #777482;
+}
+
+.answer input:focus {
+  border-color: var(--accent-2);
+}
+
+.answer button,
+.controls button,
+.next,
+.finale button {
+  border: 0;
+  background: var(--accent-2);
+  color: #06100f;
+  font-weight: 800;
+}
+
+.answer button {
+  padding: 0 1.4rem;
+  border-radius: 0 9px 9px 0;
+}
+
+.answer .answer__pass {
+  display: block;
+  margin: 0.55rem 0 0 auto;
+  padding: 0.35rem 0;
+  border: 0;
+  background: transparent;
+  color: #aaa6b3;
+  font: 600 0.66rem ui-monospace, monospace;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.82fr;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.controls button {
+  min-height: 62px;
+  padding: 0.7rem 1rem;
+  border: 1px solid #ffffff18;
+  border-radius: 9px;
+  background: #242633;
+  color: #fff;
+}
+
+.controls .button--needle {
+  border: 0;
+  background: var(--accent);
+  color: #fff;
+}
+
+.controls .button--quiet {
+  background: transparent;
+  color: #aaa6b3;
+}
+
+.controls small {
+  display: block;
+  color: #aaa6b3;
+  font-weight: 400;
+}
+
+.clue-card--result {
+  padding-top: 2.5rem;
+}
+
+.result {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-left: 5px solid var(--accent-2);
+  background: #ffffff08;
+}
+
+.result--wrong {
+  border-color: #ff5b69;
+}
+
+.result h2 {
+  margin: 0.3rem 0;
+  font: 900 2rem Impact, "Arial Black", sans-serif;
+}
+
+.result p {
+  margin: 0.2rem 0;
+  color: #aaa6b3;
+}
+
+.result > strong {
+  display: block;
+  margin-top: 0.8rem;
+  color: var(--accent-2);
+}
+
+.lineage {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.lineage article {
+  display: grid;
+  gap: 0.35rem;
+  min-height: 86px;
+  padding: 1rem;
+  border: 1px solid #ffffff16;
+  background: #090b12;
+}
+
+.lineage span,
+.lineage small {
+  color: #aaa6b3;
+  font: 500 0.63rem ui-monospace, monospace;
+}
+
+.lineage__arrow {
+  color: var(--accent-2);
+  font-size: 1.8rem;
+  text-align: center;
+}
+
+.lineage__arrow small {
+  display: block;
+  max-width: 180px;
+  color: #aaa6b3;
+  font-size: 0.6rem;
+}
+
+.liner-note {
+  margin: 0.8rem 0 1.2rem;
+  padding: 0.85rem 1rem;
+  border-left: 2px solid #ffffff24;
+  color: #aaa6b3;
+  font: italic 0.82rem / 1.5 ui-monospace, monospace;
+}
+
+.next,
+.finale button {
+  display: block;
+  margin-left: auto;
+  padding: 1rem 1.6rem;
+  border-radius: 9px;
+}
+
+.finale {
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.finale h2 {
+  margin: 0.6rem 0;
+  font: 900 clamp(2rem, 7vw, 4.5rem) Impact, "Arial Black", sans-serif;
+}
+
+.personal-best {
+  display: inline-flex;
+  gap: 0.65rem;
+  align-items: baseline;
+  margin: 1rem auto;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid #ffffff20;
+  border-radius: 999px;
+  color: #aaa6b3;
+  font: 600 0.7rem ui-monospace, monospace;
+}
+
+.personal-best.is-new {
+  border-color: var(--accent-2);
+  color: var(--accent-2);
+}
+
+.personal-best strong {
+  color: #fff;
+  font-size: 1.1rem;
+}
+
+.standings {
+  display: grid;
+  gap: 0.55rem;
+  width: min(620px, 100%);
+  margin: 1.5rem auto;
+  padding: 0;
+  list-style: none;
+}
+
+.standings li {
+  display: grid;
+  grid-template-columns: 2rem 1fr auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.8rem 1rem;
+  border: 1px solid #ffffff18;
+  border-left: 4px solid var(--player);
+  border-radius: 8px;
+  background: #090b12;
+  text-align: left;
+}
+
+.standings li > span {
+  display: grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: var(--player);
+  color: #090b12;
+  font-weight: 900;
+}
+
+.standings small {
+  color: #777482;
+}
+
+.standings b {
+  color: var(--accent-2);
+  font: 800 1rem ui-monospace, monospace;
+}
+
+.finale button {
+  margin: 2rem auto 0;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  width: min(920px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 0 0 2rem;
+  color: #74717d;
+  font: 400 0.65rem ui-monospace, monospace;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (width <= 700px) {
+  .show-header__universe {
+    padding: 0 1rem;
+  }
+
+  .show-header__streak {
+    display: none;
+  }
+
+  .show-header__score {
+    min-width: 106px;
+    padding: 0.75rem;
+  }
+
+  .marquee {
+    padding-top: 2rem;
+  }
+
+  .marquee h1 {
+    text-shadow: 4px 4px 0 var(--accent), 8px 8px #000;
+  }
+
+  .rules summary span {
+    display: none;
+  }
+
+  .rules ol {
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
+  }
+
+  .players {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .turntable {
+    display: none;
+  }
+
+  .waveform {
+    width: 100%;
+  }
+
+  .reveal-meter {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+
+  .lineage {
+    grid-template-columns: 1fr;
+  }
+
+  .lineage__arrow {
+    transform: rotate(90deg);
+  }
+
+  .standings li {
+    grid-template-columns: 2rem 1fr auto;
+  }
+
+  .standings small {
+    display: none;
+  }
+
+  footer {
+    display: grid;
+    gap: 0.4rem;
+  }
+
+  .clue-card__meta {
+    gap: 1rem;
+  }
+}
+
+@media (width <= 440px) {
+  .show-header__universe {
+    font-size: 0.65rem;
+  }
+
+  .marquee h1 {
+    font-size: 3rem;
+  }
+
+  .players {
+    grid-template-columns: 1fr;
+  }
+
+  .clue-card,
+  .finale {
+    width: calc(100% - 1rem);
+  }
+
+  .answer > div {
+    display: grid;
+  }
+
+  .answer input,
+  .answer > div > button {
+    min-height: 50px;
+    border-radius: 9px;
+  }
+
+  .answer > div > button {
+    margin-top: 0.45rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/tests/needle-drop/markup.test.js
+++ b/tests/needle-drop/markup.test.js
@@ -1,0 +1,25 @@
+import { demoEpisode } from '../../src/modes/needle-drop/core/content.js';
+import { createInitialState } from '../../src/modes/needle-drop/core/round.js';
+import { renderApp } from '../../src/modes/needle-drop/presentation/markup.js';
+
+describe('Needle Drop presentation contract', () => {
+  test('renders onboarding, active player count, and a locked pre-listen answer', () => {
+    const state = createInitialState(demoEpisode, { playerCount: 3 });
+    const markup = renderApp(state, demoEpisode, { profile: { bestScore: 0 } });
+    expect(markup).toContain('How to play');
+    expect(markup).toContain('href="?players=3" aria-current="page"');
+    expect(markup).toContain('Listen before answering');
+    expect(markup).toContain('name="answer" autocomplete="off"');
+    expect(markup).toContain('disabled');
+    expect(markup).toContain('TRACK 1/8');
+  });
+
+  test('escapes authored content at the presentation boundary', () => {
+    const episode = {
+      ...demoEpisode,
+      clues: [{ ...demoEpisode.clues[0], prompt: '<script>bad()</script>' }],
+    };
+    const state = createInitialState(episode);
+    expect(renderApp(state, episode, { profile: { bestScore: 0 } })).toContain('&lt;script&gt;');
+  });
+});

--- a/tests/needle-drop/party.test.js
+++ b/tests/needle-drop/party.test.js
@@ -1,6 +1,40 @@
-import { awardPlayer, claimBuzz, createPlayers, playerForKey } from '../../src/modes/needle-drop/core/party.js';
-describe('Needle Drop couch session',()=>{
-  test('creates one to four deterministic player seats',()=>{expect(createPlayers(9)).toHaveLength(4);expect(createPlayers(0)).toHaveLength(1);expect(createPlayers(4).map(player=>player.buzzKey)).toEqual(['1','2','3','4']);});
-  test('first valid buzz owns the turn',()=>{const players=createPlayers(4);expect(claimBuzz(players,null,'player-2')).toBe('player-2');expect(claimBuzz(players,'player-2','player-1')).toBe('player-2');});
-  test('maps keyboard input and awards immutably',()=>{const players=createPlayers(2);expect(playerForKey(players,'2').id).toBe('player-2');const awarded=awardPlayer(players,'player-2',750);expect(awarded[1].score).toBe(750);expect(players[1].score).toBe(0);});
+import {
+  awardPlayer,
+  claimBuzz,
+  createPlayers,
+  playerForKey,
+  rankPlayers,
+  recordPlayerAttempt,
+} from '../../src/modes/needle-drop/core/party.js';
+
+describe('Needle Drop couch session', () => {
+  test('creates one to four deterministic player seats', () => {
+    expect(createPlayers(9)).toHaveLength(4);
+    expect(createPlayers(0)).toHaveLength(1);
+    expect(createPlayers(3).map(player => player.buzzKey)).toEqual(['1', '2', '3']);
+  });
+
+  test('first valid eligible buzz owns the turn', () => {
+    const players = createPlayers(4);
+    expect(claimBuzz(players, null, 'player-2')).toBe('player-2');
+    expect(claimBuzz(players, 'player-2', 'player-1')).toBe('player-2');
+    expect(claimBuzz(players, null, 'player-1', ['player-1'])).toBeNull();
+  });
+
+  test('maps keyboard input and awards immutably', () => {
+    const players = createPlayers(2);
+    expect(playerForKey(players, '2').id).toBe('player-2');
+    const awarded = awardPlayer(players, 'player-2', 750);
+    expect(awarded[1]).toMatchObject({ score: 750, streak: 1, correct: 1, attempts: 1 });
+    expect(players[1].score).toBe(0);
+  });
+
+  test('resets a player streak on a miss and ranks the room deterministically', () => {
+    let players = createPlayers(3);
+    players = recordPlayerAttempt(players, 'player-2', { accepted: true, points: 500 });
+    players = recordPlayerAttempt(players, 'player-2', { accepted: false, points: 0 });
+    players = recordPlayerAttempt(players, 'player-3', { accepted: true, points: 750 });
+    expect(players[1].streak).toBe(0);
+    expect(rankPlayers(players).map(player => player.id)).toEqual(['player-3', 'player-2', 'player-1']);
+  });
 });

--- a/tests/needle-drop/profileStore.test.js
+++ b/tests/needle-drop/profileStore.test.js
@@ -1,0 +1,23 @@
+import { ProfileStore } from '../../src/modes/needle-drop/services/profileStore.js';
+
+function createStorage(initialValue) {
+  const values = new Map();
+  if (initialValue) values.set('jeoparody.needle-drop.profile.v1', initialValue);
+  return {
+    getItem: key => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe('Needle Drop local profile', () => {
+  test('keeps the highest completed solo score', () => {
+    const store = new ProfileStore(createStorage());
+    expect(store.recordCompletedScore(2200)).toEqual({ bestScore: 2200, completedRuns: 1 });
+    expect(store.recordCompletedScore(1800)).toEqual({ bestScore: 2200, completedRuns: 2 });
+  });
+
+  test('recovers from malformed storage', () => {
+    const store = new ProfileStore(createStorage('{definitely not json'));
+    expect(store.read()).toEqual({ bestScore: 0, completedRuns: 0 });
+  });
+});

--- a/tests/needle-drop/round.test.js
+++ b/tests/needle-drop/round.test.js
@@ -1,12 +1,138 @@
 import { demoEpisode, validateEpisode } from '../../src/modes/needle-drop/core/content.js';
-import { createInitialState, isAcceptedAnswer, normalizeAnswer, reduceRound, scoreForReveal, ROUND_PHASES } from '../../src/modes/needle-drop/core/round.js';
-describe('Needle Drop truth kernel',()=>{
-  test('normalizes punctuation, articles, accents, and ampersands',()=>expect(normalizeAnswer('  The Rhýthm & Blues!  ')).toBe('rhythm and blues'));
-  test('accepts only authored aliases',()=>{expect(isAcceptedAnswer('The Rubber Duck Funk!',demoEpisode.clues[0].acceptedAnswers)).toBe(true);expect(isAcceptedAnswer('something vaguely funky',demoEpisode.clues[0].acceptedAnswers)).toBe(false);});
-  test('reveal value decreases while streak bonus is capped',()=>{expect(scoreForReveal({points:1000},9)).toBe(1200);expect(scoreForReveal({points:250},0)).toBe(250);});
-  test('runs a deterministic correct-answer transition',()=>{let state=createInitialState(demoEpisode);state=reduceRound(state,{type:'PLAY_REVEAL'},demoEpisode);state=reduceRound(state,{type:'REVEAL_FINISHED'},demoEpisode);state=reduceRound(state,{type:'SUBMIT_ANSWER',answer:'Rubber Duck'},demoEpisode);expect(state).toMatchObject({phase:ROUND_PHASES.RESOLVED,score:1000,streak:1,correct:1});expect(state.attempts).toHaveLength(1);});
-  test('does not permit buying audio after resolution',()=>{let state=createInitialState(demoEpisode);state=reduceRound(state,{type:'SUBMIT_ANSWER',answer:'wrong'},demoEpisode);expect(reduceRound(state,{type:'MORE_AUDIO'},demoEpisode)).toBe(state);});
-  test('ships valid demo content',()=>expect(validateEpisode(demoEpisode)).toEqual([]));
-  test('blocks an expired rights package',()=>{const expired={...demoEpisode,clues:[{...demoEpisode.clues[0],rights:{...demoEpisode.clues[0].rights,expiresOn:'2025-01-01'}}]};expect(validateEpisode(expired)).toContain('clues[0].rights are expired');});
-  test('awards the player who wins a multiplayer buzz',()=>{let state=createInitialState(demoEpisode,{playerCount:4});state=reduceRound(state,{type:'PLAY_REVEAL'},demoEpisode);state=reduceRound(state,{type:'REVEAL_FINISHED'},demoEpisode);state=reduceRound(state,{type:'BUZZ',playerId:'player-3'},demoEpisode);state=reduceRound(state,{type:'SUBMIT_ANSWER',answer:'Rubber Duck Funk'},demoEpisode);expect(state.players[2].score).toBe(1000);expect(state.result.playerId).toBe('player-3');});
+import {
+  createInitialState,
+  isAcceptedAnswer,
+  normalizeAnswer,
+  reduceRound,
+  scoreForReveal,
+  ROUND_PHASES,
+} from '../../src/modes/needle-drop/core/round.js';
+
+const hearReveal = state => reduceRound(
+  reduceRound(state, { type: 'PLAY_REVEAL' }, demoEpisode),
+  { type: 'REVEAL_FINISHED' },
+  demoEpisode,
+);
+
+describe('Needle Drop truth kernel', () => {
+  test('normalizes punctuation, articles, accents, and ampersands', () => {
+    expect(normalizeAnswer('  The Rhýthm & Blues!  ')).toBe('rhythm and blues');
+  });
+
+  test('accepts only authored aliases', () => {
+    expect(isAcceptedAnswer('The Rubber Duck Funk!', demoEpisode.clues[0].acceptedAnswers)).toBe(true);
+    expect(isAcceptedAnswer('something vaguely funky', demoEpisode.clues[0].acceptedAnswers)).toBe(false);
+  });
+
+  test('reveal value decreases while streak bonus is capped', () => {
+    expect(scoreForReveal({ points: 1000 }, 9)).toBe(1200);
+    expect(scoreForReveal({ points: 250 }, 0)).toBe(250);
+  });
+
+  test('requires the current reveal to be heard before answering or buying audio', () => {
+    const state = createInitialState(demoEpisode);
+    expect(reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Rubber Duck' }, demoEpisode)).toBe(state);
+    expect(reduceRound(state, { type: 'MORE_AUDIO' }, demoEpisode)).toBe(state);
+  });
+
+  test('runs a deterministic correct-answer transition', () => {
+    let state = hearReveal(createInitialState(demoEpisode));
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Rubber Duck' }, demoEpisode);
+    expect(state).toMatchObject({
+      phase: ROUND_PHASES.RESOLVED,
+      score: 1000,
+      streak: 1,
+      correct: 1,
+    });
+    expect(state.players[0]).toMatchObject({ score: 1000, streak: 1, correct: 1 });
+    expect(state.attempts).toHaveLength(1);
+  });
+
+  test('turns a solo miss into a lower-value retry instead of ending the clue', () => {
+    let state = hearReveal(createInitialState(demoEpisode));
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Definitely Prince' }, demoEpisode);
+    expect(state).toMatchObject({ phase: ROUND_PHASES.ANSWERING, activePlayerId: null });
+    expect(state.blockedPlayerIds).toEqual(['player-1']);
+
+    state = reduceRound(state, { type: 'MORE_AUDIO' }, demoEpisode);
+    expect(state).toMatchObject({ phase: ROUND_PHASES.READY, revealIndex: 1 });
+    expect(state.blockedPlayerIds).toEqual([]);
+
+    state = hearReveal(state);
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Rubber Duck Funk' }, demoEpisode);
+    expect(state.result.points).toBe(750);
+  });
+
+  test('opens a steal after a wrong multiplayer answer', () => {
+    let state = hearReveal(createInitialState(demoEpisode, { playerCount: 4 }));
+    state = reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode);
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Wrong groove' }, demoEpisode);
+    expect(state.phase).toBe(ROUND_PHASES.ANSWERING);
+    expect(state.blockedPlayerIds).toContain('player-1');
+
+    state = reduceRound(state, { type: 'BUZZ', playerId: 'player-2' }, demoEpisode);
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'Rubber Duck Funk' }, demoEpisode);
+    expect(state.phase).toBe(ROUND_PHASES.RESOLVED);
+    expect(state.players[1]).toMatchObject({ score: 1000, correct: 1 });
+    expect(state.players[0]).toMatchObject({ score: 0, streak: 0, attempts: 1 });
+  });
+
+  test('lets a buzz winner pass the mic without inventing an answer', () => {
+    let state = hearReveal(createInitialState(demoEpisode, { playerCount: 2 }));
+    state = reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode);
+    state = reduceRound(state, { type: 'PASS' }, demoEpisode);
+    expect(state.phase).toBe(ROUND_PHASES.ANSWERING);
+    expect(state.activePlayerId).toBeNull();
+    expect(state.blockedPlayerIds).toEqual(['player-1']);
+    expect(state.lastAttempt).toMatchObject({ passed: true, answer: '' });
+  });
+
+  test('rejects buzzes before playback and from locked-out players', () => {
+    let state = createInitialState(demoEpisode, { playerCount: 2 });
+    expect(reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode)).toBe(state);
+    state = hearReveal(state);
+    state = reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode);
+    state = reduceRound(state, { type: 'SUBMIT_ANSWER', answer: 'wrong' }, demoEpisode);
+    expect(reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode)).toBe(state);
+  });
+
+  test('allows the room to reveal the answer after hearing audio', () => {
+    let state = hearReveal(createInitialState(demoEpisode, { playerCount: 2 }));
+    state = reduceRound(state, { type: 'GIVE_UP' }, demoEpisode);
+    expect(state).toMatchObject({ phase: ROUND_PHASES.RESOLVED, correct: 0 });
+    expect(state.result).toMatchObject({ gaveUp: true, accepted: false });
+  });
+
+  test('recovers from an audio failure without pretending the reveal was heard', () => {
+    let state = createInitialState(demoEpisode);
+    state = reduceRound(state, { type: 'PLAY_REVEAL' }, demoEpisode);
+    state = reduceRound(state, { type: 'AUDIO_FAILED', message: 'speaker on vacation' }, demoEpisode);
+    expect(state).toMatchObject({
+      phase: ROUND_PHASES.READY,
+      listenedRevealIndex: -1,
+      audioError: 'speaker on vacation',
+    });
+  });
+
+  test('does not permit buying audio after resolution', () => {
+    let state = hearReveal(createInitialState(demoEpisode));
+    state = reduceRound(state, { type: 'GIVE_UP' }, demoEpisode);
+    expect(reduceRound(state, { type: 'MORE_AUDIO' }, demoEpisode)).toBe(state);
+  });
+
+  test('ships a larger valid demo crate', () => {
+    expect(validateEpisode(demoEpisode)).toEqual([]);
+    expect(demoEpisode.clues).toHaveLength(8);
+  });
+
+  test('blocks an expired rights package', () => {
+    const expired = {
+      ...demoEpisode,
+      clues: [{
+        ...demoEpisode.clues[0],
+        rights: { ...demoEpisode.clues[0].rights, expiresOn: '2025-01-01' },
+      }],
+    };
+    expect(validateEpisode(expired, '2026-08-22')).toContain('clues[0].rights are expired');
+  });
 });


### PR DESCRIPTION
## Outcome

Needle Drop 1.2 turns the proving shell into a fair, replayable solo and party game while preserving the original visual identity and rights-safe audio architecture.

## Gameplay

- requires a completed clip before answers or value reduction
- wrong solo guesses unlock a longer, lower-value retry
- wrong party guesses lock only that player and open a steal
- adds pass-the-mic and reveal-answer escape hatches
- tracks streaks, correct answers, attempts, and scores per player
- adds deterministic party standings and a real winner finale
- adds 3P rooms alongside 1P, 2P, and 4P
- doubles the original procedural demo crate from four to eight clues

## Experience and reliability

- phase-specific host calls and compact onboarding
- free replay distinct from buying more audio
- active/locked player text states, focus management, and live status
- buzz shortcuts ignored while typing or using modifiers
- audio failure returns to a retryable state
- stale playback completion cannot advance a newer round
- optional failure-tolerant solo personal best
- escaped presentation boundary and responsive desktop/mobile polish

## Architecture and roadmap

- moves state-to-HTML rendering into `presentation/markup.js`
- keeps the reducer serializable and deterministic
- adds a dated comprehensive Now/Next/Later plan and updates the architecture contract
- adds a dedicated Playwright party-steal and mobile-layout runtime gate to CI
- adds a second axe audit for the Needle Drop entry

## Verification

- JavaScript lint: zero errors (legacy warnings elsewhere unchanged)
- CSS lint: zero errors and zero warnings
- content and rights validation: 8 valid clues
- Jest: 63/63 tests pass
- Vite production build: pass
- automated desktop party flow: playback → wrong answer → lockout → steal → scoring → result
- automated 390px mobile layout: pass, no horizontal overflow
- `git diff --check`: pass

All demo audio remains procedurally synthesized and original. Catalog audio remains blocked behind immutable manifests, checksums, excerpt limits, and interactive-game rights validation. The lawyers may remain seated but should not become comfortable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Needle Drop now includes expanded clue content, richer reveal progression, solo streak scoring, and personal-best tracking.
  * Party play supports buzzing, passing, steals, player lockouts, attempts, rankings, and finale standings.
  * Added improved audio recovery, mobile layouts, onboarding, rules, and round guidance.
* **Accessibility & Style**
  * Added clearer focus states, reduced-motion support, responsive layouts, and improved interaction feedback.
* **Bug Fixes**
  * Prevented invalid actions during audio playback and improved handling of audio and storage failures.
* **Quality**
  * Added automated browser checks covering desktop party play, mobile onboarding, scoring, accessibility, and runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->