### PR TITLE
Fix: restore canonical Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,10 +27,6 @@ jobs:
       - run: npm run needle-drop:validate
       - run: npm test -- --runInBand
       - run: npm run build
-      - name: Select GitHub Actions as the sole Pages source
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh api --method PUT "repos/${GITHUB_REPOSITORY}/pages" -f build_type=workflow
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
## Fix

Remove the unsupported Pages settings API mutation that GitHub's ephemeral workflow token correctly rejected with HTTP 403.

The prior cleanup remains intact: the redundant repository Pages workflow is still deleted, leaving the validated `Deploy GitHub Pages` workflow as the only repo-owned publisher.

## Scope

- one workflow file
- four lines removed
- no product code changes
- `git diff --check` passes

GitHub Pages source selection is a repository-owner setting and is intentionally not smuggled through a token that lacks administration authority.