### PR TITLE
Fix: preserve solo reveal choices

### DIFF
--- a/src/modes/needle-drop/core/round.js
+++ b/src/modes/needle-drop/core/round.js
@@ -72,7 +72,7 @@ export function reduceRound(state, action, episode) {
   switch (action.type) {
     case 'PLAY_REVEAL': {
       const canPlay = [ROUND_PHASES.READY, ROUND_PHASES.ANSWERING].includes(state.phase)
-        && !state.activePlayerId;
+        && (!state.activePlayerId || state.players.length === 1);
       if (!canPlay) return state;
       return { ...state, phase: ROUND_PHASES.LISTENING, audioError: null };
     }
@@ -112,9 +112,10 @@ export function reduceRound(state, action, episode) {
 
     case 'MORE_AUDIO': {
       const heardCurrentReveal = state.listenedRevealIndex >= state.revealIndex;
+      const roomCanChoose = !state.activePlayerId || state.players.length === 1;
       const canBuy = state.phase === ROUND_PHASES.ANSWERING
         && heardCurrentReveal
-        && !state.activePlayerId
+        && roomCanChoose
         && state.revealIndex < clue.reveals.length - 1;
       if (!canBuy) return state;
 
@@ -184,9 +185,10 @@ export function reduceRound(state, action, episode) {
 
     case 'GIVE_UP': {
       const hasHeardAudio = state.listenedRevealIndex >= 0;
+      const roomCanChoose = !state.activePlayerId || state.players.length === 1;
       const canGiveUp = state.phase === ROUND_PHASES.ANSWERING
         && hasHeardAudio
-        && !state.activePlayerId;
+        && roomCanChoose;
       if (!canGiveUp) return state;
 
       const attempt = {

--- a/src/modes/needle-drop/presentation/markup.js
+++ b/src/modes/needle-drop/presentation/markup.js
@@ -131,15 +131,16 @@ function roundMarkup(state, episode, clue, reveal) {
   const canAnswer = state.phase === ROUND_PHASES.ANSWERING
     && activePlayer
     && !state.blockedPlayerIds.includes(activePlayer.id);
+  const roomCanChoose = !state.activePlayerId || state.players.length === 1;
   const canPlay = [ROUND_PHASES.READY, ROUND_PHASES.ANSWERING].includes(state.phase)
-    && !state.activePlayerId;
+    && roomCanChoose;
   const canBuy = state.phase === ROUND_PHASES.ANSWERING
     && heardCurrentReveal
-    && !state.activePlayerId
+    && roomCanChoose
     && state.revealIndex < clue.reveals.length - 1;
   const canGiveUp = state.phase === ROUND_PHASES.ANSWERING
     && state.listenedRevealIndex >= 0
-    && !state.activePlayerId;
+    && roomCanChoose;
   const nextReveal = clue.reveals[state.revealIndex + 1];
   const answerLabel = canAnswer
     ? `${activePlayer.name}'s answer`

--- a/tests/needle-drop/round.test.js
+++ b/tests/needle-drop/round.test.js
@@ -63,6 +63,18 @@ describe('Needle Drop truth kernel', () => {
     expect(state.result.points).toBe(750);
   });
 
+  test('keeps replay, longer audio, and surrender available during a solo answer turn', () => {
+    const heard = hearReveal(createInitialState(demoEpisode));
+    expect(heard.activePlayerId).toBe('player-1');
+    expect(reduceRound(heard, { type: 'PLAY_REVEAL' }, demoEpisode).phase).toBe(ROUND_PHASES.LISTENING);
+    expect(reduceRound(heard, { type: 'MORE_AUDIO' }, demoEpisode)).toMatchObject({
+      phase: ROUND_PHASES.READY,
+      revealIndex: 1,
+      activePlayerId: null,
+    });
+    expect(reduceRound(heard, { type: 'GIVE_UP' }, demoEpisode).phase).toBe(ROUND_PHASES.RESOLVED);
+  });
+
   test('opens a steal after a wrong multiplayer answer', () => {
     let state = hearReveal(createInitialState(demoEpisode, { playerCount: 4 }));
     state = reduceRound(state, { type: 'BUZZ', playerId: 'player-1' }, demoEpisode);


### PR DESCRIPTION
## Problem

The live release check found that assigning the solo player as the active answerer also disabled replay, longer-audio purchase, and reveal-answer. The reducer was applying the party rule—no room actions while somebody owns the mic—to the solo seat.

## Fix

- treat the solo active answerer as eligible to replay the current clip
- keep `Buy more audio` available after the clip is heard
- keep `Reveal answer` available as a solo concession
- retain the stricter party rule once a player has buzzed
- add a reducer regression test covering all three solo choices

## Verification

- Needle Drop lint: zero errors
- CSS lint: zero errors and warnings
- Needle Drop tests: 24/24 pass
- 8-clue content and rights validation: pass
- production build: pass
- `git diff --check`: pass