### PR TITLE
Needle Drop 1.3: deterministic crates and playtest receipts

### DIFF
--- a/DEV_JOURNAL.md
+++ b/DEV_JOURNAL.md
@@ -137,6 +137,15 @@ Append entries newest-first immediately below this heading when practical:
 
 ---
 
+### 2026-08-23 — Codex — make Needle Drop replayable and measurable
+- **Read/inspected:** the deployed 1.2 Needle Drop loop, reducer/presentation/audio/profile boundaries, browser runtime contract, second-pass roadmap, canonical migration doctrine, and mobile/desktop visual evidence.
+- **Changed:** added deterministic Quick Hit / Side A / Full Crate session projections; safe seed/query normalization; same-crate and fresh-crate flows; format-aware personal-best migration; a local-only semantic `SessionRecorder`; finale receipts and copyable result text; expanded responsive presentation; and a complete three-record browser run.
+- **Evidence/tests:** 70/70 repository tests; 30/30 Needle Drop tests; zero Needle Drop lint errors; zero CSS lint findings; eight-clue rights validation; production Vite build; desktop 4P steal, 390px mobile, and complete Quick Hit browser flows.
+- **Decisions:** `core/round.js` remains the only gameplay-truth owner. A session is a deterministic projection of a cleared immutable package. The recorder observes accepted transitions, stores no typed answers, and sends nothing off-device.
+- **Unresolved:** GitHub Pages still has a repository-level legacy branch publisher enabled; after merge the canonical Actions deploy must finish last until an owner selects **Settings → Pages → Source: GitHub Actions**.
+- **Next lead domino:** run blind Quick Hit and Side A sessions, then use observed dispute/room-reaction evidence to choose between a host/sting director and the phone `InputGateway` calibration slice.
+- **Refs:** `feat/needle-drop-third-pass`, `docs/NEEDLE_DROP_THIRD_PASS_2026-08-23.md`.
+
 ### 2026-08-20 — Codex — close responsive host-stage review findings
 - **Read/inspected:** PR #32 head and the latest CodeRabbit review threads for host-stage timing, personality-change geometry ownership, and the stairs dispatch.
 - **Changed:** moved personality-change scale timing into `HostStageActor`; made celebrate/surprise completion wait for both stage and mood work; added a reduced-motion-aware `fakeStairs()` beat and routed the stairs animation to it.

--- a/docs/NEEDLE_DROP_ARCHITECTURE.md
+++ b/docs/NEEDLE_DROP_ARCHITECTURE.md
@@ -15,18 +15,21 @@ Needle Drop is a composable JeoPARODY music-game mode. The proving build asks wh
 5. **The build stays independently playable.** `needle-drop.html` is a separate Vite entry point while the mode proves itself.
 6. **A miss is gameplay, not a funeral.** Wrong solo answers unlock the next reveal; wrong party answers lock only that player for the current clip and open a steal. The reducer adjudicates every lockout.
 7. **Persistence is optional.** `ProfileStore` keeps a solo personal best, but storage failure never blocks a round. Scores are not national secrets, despite what the scoreboard implies.
+8. **Sessions are projections, not new truth.** `core/session.js` deterministically selects a cleared clue order from format + seed. `SessionRecorder` observes accepted transitions, redacts typed answers, and computes a local finale receipt without changing reducer state or sending telemetry.
 
 ```text
 needle-drop.html
   └─ main.js                    composition root + semantic events
       ├─ core/round.js          deterministic truth kernel
       ├─ core/content.js        episode schema, validator, demo
+      ├─ core/session.js        deterministic format + seed projection
       ├─ services/audioRuntime.js implementation router
       ├─ services/synthAudio.js procedural demo adapter
       ├─ services/decodedBufferAudio.js integrity-checked asset adapter
       ├─ presentation/markup.js  escaped state-to-view boundary
       ├─ presentation/Waveform.js
       ├─ services/profileStore.js optional local personal best
+      ├─ services/sessionRecorder.js privacy-first semantic receipt
       └─ styles.css
 ```
 

--- a/docs/NEEDLE_DROP_THIRD_PASS_2026-08-23.md
+++ b/docs/NEEDLE_DROP_THIRD_PASS_2026-08-23.md
@@ -1,0 +1,61 @@
+# Needle Drop — third-pass proving plan
+
+**Date:** 2026-08-23  
+**Release target:** proving build 1.3  
+**Lead domino:** make every session replayable, measurable, and easy to fit into a real room.
+
+## Product decision
+
+The 1.2 loop is playable. The next uncertainty is whether people finish it, replay it, and create recognizable room moments. Eight fixed clues cannot answer that reliably. The third pass adds three session formats, deterministic crate seeds, a local-only semantic recorder, and a finale receipt. No event leaves the device.
+
+| Format | Clues | Intended use |
+| --- | ---: | --- |
+| Quick Hit | 3 | onboarding, demos, impatient relatives |
+| Side A | 5 | ordinary couch session |
+| Full Crate | 8 | complete proving run |
+
+## Architecture contract
+
+1. `core/session.js` owns format normalization, seed normalization, deterministic ordering, and session URLs.
+2. `core/round.js` remains the sole owner of scoring, attempts, phase, locks, and progression.
+3. `SessionRecorder` observes accepted reducer transitions. It never changes game truth and never records answer text.
+4. Presentation receives a computed summary and safe URLs. It does not inspect storage, clocks, randomness, or browser APIs.
+5. The original episode manifest remains immutable. A session episode is a shallow, deterministic projection over the cleared source package.
+
+```text
+cleared episode + format + seed
+              ↓
+      session projection
+              ↓
+      deterministic reducer
+              ↓
+ semantic transition observer
+              ↓
+ local finale receipt / copy text
+```
+
+## Release slice
+
+- Quick Hit, Side A, and Full Crate selectors that preserve player count and seed.
+- Original-order compatibility plus deterministic fresh-crate seeds.
+- Format-aware personal bests with migration from the 1.2 profile.
+- Local session metrics: guesses, first-drop hits, replays, reveals purchased, buzzes, steals, average reveal depth, and elapsed time.
+- Finale receipt, copyable summary, same-crate rematch, and fresh-crate link.
+- Unit tests for determinism, query safety, privacy, summaries, and profile migration.
+- Browser coverage for a complete Quick Hit session plus existing desktop party and mobile checks.
+
+## Deliberate exclusions
+
+- No remote analytics endpoint or invisible fingerprinting.
+- No phone controllers yet; the recorder first establishes the event vocabulary they will consume.
+- No licensed catalog audio.
+- No AI adjudicator.
+- No second game-state owner disguised as a “session manager,” because we have suffered enough.
+
+## Graduation evidence
+
+- Identical seed + package version produces identical clue order.
+- Changing format never mutates or bypasses the rights-validated manifest.
+- Recorder output contains mechanics and identifiers, never typed answers.
+- The full browser suite completes a three-clue run and verifies the finale receipt.
+- Production serves compiled assets and the public Quick Hit URL completes without horizontal overflow or runtime errors.

--- a/scripts/needle-drop-runtime-check.mjs
+++ b/scripts/needle-drop-runtime-check.mjs
@@ -87,12 +87,44 @@ async function runMobileLayout(browser) {
   await page.close();
 }
 
+async function runQuickCrate(browser) {
+  const page = await browser.newPage({ viewport: { width: 1024, height: 900 } });
+  const runtimeErrors = [];
+  page.on('pageerror', error => runtimeErrors.push(error.message));
+  page.on('console', message => {
+    if (message.type() === 'error') runtimeErrors.push(message.text());
+  });
+
+  await page.goto(`${BASE_URL}/needle-drop.html?players=1&crate=quick&seed=original`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#game[data-phase="ready"]');
+  assert(await page.getByRole('link', { name: /Quick Hit/ }).getAttribute('aria-current') === 'page', 'quick crate must be selected');
+  assert((await page.locator('.clue-card__meta').textContent()).includes('TRACK 1/3'), 'quick crate must contain three tracks');
+
+  for (const answer of ['Rubber Duck Funk', 'Midnight Pager', 'Municipal Cowbell']) {
+    await page.getByRole('button', { name: /Drop the needle/ }).click();
+    await page.waitForSelector('#game[data-phase="answering"]');
+    await page.locator('#answer').fill(answer);
+    await page.getByRole('button', { name: 'Lock it' }).click();
+    await page.waitForSelector('#game[data-phase="resolved"]');
+    await page.getByRole('button', { name: /Next record|Close the crate/ }).click();
+  }
+
+  await page.waitForSelector('#game[data-phase="complete"]');
+  assert(await page.getByText('SESSION RECEIPT').isVisible(), 'completed crate must expose its session receipt');
+  assert(await page.getByRole('button', { name: 'Rematch same crate' }).isVisible(), 'finale must offer a deterministic rematch');
+  assert(await page.getByRole('link', { name: /Fresh crate/ }).isVisible(), 'finale must offer a new seed');
+  await page.screenshot({ path: path.join(OUT_DIR, 'quick-crate-finale.png'), fullPage: true });
+  assert(runtimeErrors.length === 0, `quick crate emitted runtime errors: ${runtimeErrors.join(' | ')}`);
+  await page.close();
+}
+
 async function main() {
   fs.mkdirSync(OUT_DIR, { recursive: true });
   const browser = await chromium.launch({ headless: true });
   try {
     await runPartyFlow(browser);
     await runMobileLayout(browser);
+    await runQuickCrate(browser);
     console.log(`Needle Drop runtime check passed. Evidence: ${OUT_DIR}`);
   } finally {
     await browser.close();

--- a/src/modes/needle-drop/core/content.js
+++ b/src/modes/needle-drop/core/content.js
@@ -27,7 +27,7 @@ const synth = sequence => ({ kind: 'synth', sequence });
 
 export const demoEpisode = Object.freeze({
   schemaVersion: 1,
-  packageVersion: '1.2.0',
+  packageVersion: '1.3.0',
   id: 'nd-demo-001',
   title: 'The Unlicensed Basement Tapes',
   description: 'Eight original musical families. No catalog lawyers were awakened.',

--- a/src/modes/needle-drop/core/session.js
+++ b/src/modes/needle-drop/core/session.js
@@ -1,0 +1,79 @@
+export const CRATE_FORMATS = Object.freeze([
+  Object.freeze({ id: 'quick', label: 'Quick Hit', clueCount: 3, description: 'three records' }),
+  Object.freeze({ id: 'side-a', label: 'Side A', clueCount: 5, description: 'five records' }),
+  Object.freeze({ id: 'full', label: 'Full Crate', clueCount: 8, description: 'all eight records' }),
+]);
+
+export const DEFAULT_CRATE_FORMAT = 'full';
+export const ORIGINAL_CRATE_SEED = 'original';
+
+export function normalizeCrateFormat(value) {
+  return CRATE_FORMATS.find(format => format.id === value)
+    || CRATE_FORMATS.find(format => format.id === DEFAULT_CRATE_FORMAT);
+}
+
+export function normalizeSeed(value) {
+  const normalized = String(value || ORIGINAL_CRATE_SEED)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '')
+    .slice(0, 24);
+  return normalized || ORIGINAL_CRATE_SEED;
+}
+
+function hashSeed(value) {
+  let hash = 2166136261;
+  for (const character of value) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function randomFromSeed(seed) {
+  let state = hashSeed(seed);
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function seededShuffle(items, seed) {
+  if (normalizeSeed(seed) === ORIGINAL_CRATE_SEED) return [...items];
+
+  const shuffled = [...items];
+  const random = randomFromSeed(normalizeSeed(seed));
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const target = Math.floor(random() * (index + 1));
+    [shuffled[index], shuffled[target]] = [shuffled[target], shuffled[index]];
+  }
+  return shuffled;
+}
+
+export function createSessionEpisode(episode, options = {}) {
+  const format = normalizeCrateFormat(options.formatId);
+  const seed = normalizeSeed(options.seed);
+  const clues = seededShuffle(episode.clues, seed).slice(0, format.clueCount);
+
+  return Object.freeze({
+    ...episode,
+    session: Object.freeze({ formatId: format.id, formatLabel: format.label, seed }),
+    clues: Object.freeze(clues),
+  });
+}
+
+export function createSessionUrl({ playerCount = 1, formatId, seed }, basePath = '') {
+  const params = new URLSearchParams({
+    players: String(Math.max(1, Math.min(4, Number(playerCount) || 1))),
+    crate: normalizeCrateFormat(formatId).id,
+    seed: normalizeSeed(seed),
+  });
+  return `${basePath}?${params.toString()}`;
+}
+
+export function createFreshSeed(randomValue = Math.random()) {
+  const safeValue = Number.isFinite(randomValue) ? Math.abs(randomValue % 1) : 0;
+  return Math.floor(safeValue * 0xFFFFFFFF).toString(36).padStart(7, '0').slice(0, 7);
+}

--- a/src/modes/needle-drop/main.js
+++ b/src/modes/needle-drop/main.js
@@ -2,10 +2,12 @@ import './styles.css';
 import { demoEpisode, validateEpisode } from './core/content.js';
 import { playerForKey } from './core/party.js';
 import { createInitialState, reduceRound, ROUND_PHASES } from './core/round.js';
+import { createFreshSeed, createSessionEpisode, createSessionUrl } from './core/session.js';
 import { renderApp } from './presentation/markup.js';
 import { Waveform } from './presentation/Waveform.js';
 import { AudioRuntime } from './services/audioRuntime.js';
 import { ProfileStore } from './services/profileStore.js';
+import { SessionRecorder, sessionResultText } from './services/sessionRecorder.js';
 
 const errors = validateEpisode(demoEpisode);
 if (errors.length) throw new Error(`Needle Drop content invalid:\n${errors.join('\n')}`);
@@ -15,13 +17,27 @@ if (!app) throw new Error('Needle Drop mount point is missing. The crate cannot 
 
 const audio = new AudioRuntime();
 const profileStore = new ProfileStore();
-const requestedPlayers = new URLSearchParams(window.location.search).get('players');
+const params = new URLSearchParams(window.location.search);
+const requestedPlayers = params.get('players');
+const episode = createSessionEpisode(demoEpisode, {
+  formatId: params.get('crate'),
+  seed: params.get('seed'),
+});
+const session = episode.session;
+const freshCrateUrl = createSessionUrl({
+  playerCount: requestedPlayers,
+  formatId: session.formatId,
+  seed: createFreshSeed(),
+});
 
-let state = createInitialState(demoEpisode, { playerCount: requestedPlayers });
+let state = createInitialState(episode, { playerCount: requestedPlayers });
 let profile = profileStore.read();
 let waveform;
 let playbackToken = 0;
 let isNewBest = false;
+let sessionSummary = null;
+let copyStatus = '';
+const sessionRecorder = new SessionRecorder();
 
 function emit(name, detail = {}) {
   window.dispatchEvent(new CustomEvent(`needle-drop:${name}`, {
@@ -31,6 +47,10 @@ function emit(name, detail = {}) {
 
 function focusAfter(actionType) {
   window.queueMicrotask(() => {
+    if (actionType === 'COPY_RESULT') {
+      document.querySelector('[data-action="copy-result"]')?.focus();
+      return;
+    }
     if (state.phase === ROUND_PHASES.COMPLETE) {
       document.querySelector('#finale-heading')?.focus();
       return;
@@ -57,7 +77,14 @@ function focusAfter(actionType) {
 
 function render(actionType) {
   waveform?.destroy();
-  app.innerHTML = renderApp(state, demoEpisode, { profile, isNewBest });
+  app.innerHTML = renderApp(state, episode, {
+    profile,
+    isNewBest,
+    session,
+    sessionSummary,
+    freshCrateUrl,
+    copyStatus,
+  });
 
   const canvas = document.querySelector('#waveform');
   if (canvas) {
@@ -72,18 +99,24 @@ function render(actionType) {
 
 function dispatch(action) {
   const previous = state;
-  const next = reduceRound(state, action, demoEpisode);
+  const next = reduceRound(state, action, episode);
   if (next === previous) return false;
 
   state = next;
+  sessionRecorder.record(action, previous, next);
   if (state.phase === ROUND_PHASES.COMPLETE && previous.phase !== ROUND_PHASES.COMPLETE) {
+    sessionSummary = sessionRecorder.summarize(state, episode);
     if (state.players.length === 1) {
-      const previousBest = profile.bestScore;
-      profile = profileStore.recordCompletedScore(state.score);
+      const previousBest = profile.bestScores?.[session.formatId] || 0;
+      profile = profileStore.recordCompletedScore(state.score, session.formatId);
       isNewBest = state.score > previousBest;
     }
   }
-  if (action.type === 'RESTART') isNewBest = false;
+  if (action.type === 'RESTART') {
+    isNewBest = false;
+    sessionSummary = null;
+    copyStatus = '';
+  }
 
   emit(action.type.toLowerCase(), { action, previous });
   render(action.type);
@@ -93,7 +126,7 @@ function dispatch(action) {
 async function playCurrentReveal() {
   if (!dispatch({ type: 'PLAY_REVEAL' })) return;
 
-  const clue = demoEpisode.clues[state.clueIndex];
+  const clue = episode.clues[state.clueIndex];
   const reveal = clue.reveals[state.revealIndex];
   const token = ++playbackToken;
   waveform?.animate(reveal.duration * 1000);
@@ -108,6 +141,30 @@ async function playCurrentReveal() {
     emit('audio_error', { error: message, clueId: clue.id, revealIndex: state.revealIndex });
     dispatch({ type: 'AUDIO_FAILED', message });
   }
+}
+
+async function copySessionResult() {
+  if (!sessionSummary) return;
+  const text = sessionResultText(state, episode, sessionSummary);
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const field = document.createElement('textarea');
+      field.value = text;
+      field.setAttribute('readonly', '');
+      field.className = 'copy-field';
+      document.body.append(field);
+      field.select();
+      document.execCommand('copy');
+      field.remove();
+    }
+    copyStatus = 'Result copied. The clipboard now knows too much.';
+  } catch {
+    copyStatus = 'Copy blocked. The clipboard has retained counsel.';
+  }
+  render('COPY_RESULT');
 }
 
 function stopPlayback() {
@@ -139,6 +196,9 @@ app.addEventListener('click', event => {
     case 'restart':
       stopPlayback();
       dispatch({ type: 'RESTART' });
+      break;
+    case 'copy-result':
+      copySessionResult();
       break;
     default:
       break;

--- a/src/modes/needle-drop/presentation/markup.js
+++ b/src/modes/needle-drop/presentation/markup.js
@@ -1,5 +1,6 @@
 import { rankPlayers } from '../core/party.js';
 import { ROUND_PHASES } from '../core/round.js';
+import { CRATE_FORMATS, createSessionUrl } from '../core/session.js';
 
 export function escapeHtml(value = '') {
   return String(value)
@@ -12,9 +13,17 @@ export function escapeHtml(value = '') {
 
 const formatPoints = value => Number(value || 0).toLocaleString();
 
-function playerCountMarkup(count) {
+function playerCountMarkup(count, session) {
   return `<nav class="player-count" aria-label="Player count">
-    ${[1, 2, 3, 4].map(value => `<a href="?players=${value}" ${value === count ? 'aria-current="page"' : ''}>${value}P</a>`).join('')}
+    ${[1, 2, 3, 4].map(value => `<a href="${escapeHtml(createSessionUrl({ playerCount: value, formatId: session.formatId, seed: session.seed }))}" ${value === count ? 'aria-current="page"' : ''}>${value}P</a>`).join('')}
+  </nav>`;
+}
+
+function crateFormatsMarkup(playerCount, session) {
+  return `<nav class="crate-formats" aria-label="Crate length">
+    ${CRATE_FORMATS.map(format => `<a href="${escapeHtml(createSessionUrl({ playerCount, formatId: format.id, seed: session.seed }))}" ${format.id === session.formatId ? 'aria-current="page"' : ''}>
+      <strong>${escapeHtml(format.label)}</strong><small>${escapeHtml(format.description)}</small>
+    </a>`).join('')}
   </nav>`;
 }
 
@@ -178,7 +187,25 @@ function roundMarkup(state, episode, clue, reveal) {
   </section>`;
 }
 
-function finaleMarkup(state, episode, profile, isNewBest) {
+function receiptMarkup(summary) {
+  if (!summary) return '';
+  return `<section class="session-receipt" aria-labelledby="receipt-heading">
+    <p class="eyebrow" id="receipt-heading">SESSION RECEIPT</p>
+    <dl>
+      <div><dt>First-drop hits</dt><dd>${summary.firstDropHits}</dd></div>
+      <div><dt>Guesses</dt><dd>${summary.guesses}</dd></div>
+      <div><dt>Replays</dt><dd>${summary.replays}</dd></div>
+      <div><dt>More audio</dt><dd>${summary.revealsBought}</dd></div>
+      ${summary.buzzes ? `<div><dt>Buzzes</dt><dd>${summary.buzzes}</dd></div>` : ''}
+      ${summary.steals ? `<div><dt>Steals</dt><dd>${summary.steals}</dd></div>` : ''}
+      <div><dt>Avg. reveal</dt><dd>${summary.averageReveal}</dd></div>
+      <div><dt>Elapsed</dt><dd>${summary.durationSeconds}s</dd></div>
+    </dl>
+    <p>No telemetry left this device. Even the spies had to play locally.</p>
+  </section>`;
+}
+
+function finaleMarkup(state, episode, profile, isNewBest, options) {
   const ranked = rankPlayers(state.players);
   const topScore = ranked[0]?.score || 0;
   const winners = ranked.filter(player => player.score === topScore);
@@ -186,19 +213,33 @@ function finaleMarkup(state, episode, profile, isNewBest) {
     ? `${state.correct}/${episode.clues.length} identified`
     : (winners.length > 1 ? 'A crate-sharing tie' : `${winners[0].name} wins the crate`);
 
+  const formatBest = profile.bestScores?.[options.session.formatId] || 0;
+
   return `<section class="finale">
     <p class="eyebrow">CRATE CLOSED</p>
     <h2 id="finale-heading" tabindex="-1">${escapeHtml(title)}</h2>
+    <p>${escapeHtml(options.session.formatLabel)} · crate <code>${escapeHtml(options.session.seed)}</code></p>
     <p>${formatPoints(state.score)} room points. The waveform has declined to comment.</p>
-    ${state.players.length === 1 ? `<p class="personal-best ${isNewBest ? 'is-new' : ''}">${isNewBest ? 'NEW PERSONAL BEST' : 'PERSONAL BEST'} <strong>${formatPoints(profile.bestScore)}</strong></p>` : ''}
+    ${state.players.length === 1 ? `<p class="personal-best ${isNewBest ? 'is-new' : ''}">${isNewBest ? 'NEW FORMAT BEST' : 'FORMAT BEST'} <strong>${formatPoints(formatBest)}</strong></p>` : ''}
     <ol class="standings" aria-label="Final standings">
       ${ranked.map((player, index) => `<li style="--player:${player.color}"><span>${index + 1}</span><strong>${escapeHtml(player.name)}</strong><small>${player.correct} correct</small><b>${formatPoints(player.score)}</b></li>`).join('')}
     </ol>
-    <button type="button" data-action="restart">Spin it again</button>
+    ${receiptMarkup(options.sessionSummary)}
+    <div class="finale__actions">
+      <button type="button" data-action="restart">Rematch same crate</button>
+      <a href="${escapeHtml(options.freshCrateUrl)}">Fresh crate →</a>
+      <button type="button" class="button--quiet" data-action="copy-result">Copy result</button>
+    </div>
+    <p class="copy-status" role="status" aria-live="polite">${escapeHtml(options.copyStatus)}</p>
   </section>`;
 }
 
-export function renderApp(state, episode, { profile, isNewBest = false } = {}) {
+export function renderApp(state, episode, options = {}) {
+  const {
+    profile = { bestScores: {} },
+    isNewBest = false,
+    session = episode.session || { formatId: 'full', formatLabel: 'Full Crate', seed: 'original' },
+  } = options;
   const clue = episode.clues[state.clueIndex];
   const reveal = clue?.reveals[state.revealIndex];
   const complete = state.phase === ROUND_PHASES.COMPLETE;
@@ -208,7 +249,7 @@ export function renderApp(state, episode, { profile, isNewBest = false } = {}) {
     ? { label: 'LEAD', value: formatPoints(ranked[0]?.score) }
     : { label: 'STREAK', value: state.players[0]?.streak || 0 };
   const body = complete
-    ? finaleMarkup(state, episode, profile, isNewBest)
+    ? finaleMarkup(state, episode, profile, isNewBest, { ...options, session })
     : roundMarkup(state, episode, clue, reveal);
 
   return `<main id="game" class="stage" data-phase="${state.phase}" data-reveal-index="${state.revealIndex}" style="--accent:${clue?.palette?.[0] || '#ff3f81'};--accent-2:${clue?.palette?.[1] || '#00d7d7'}">
@@ -221,7 +262,8 @@ export function renderApp(state, episode, { profile, isNewBest = false } = {}) {
       <span>PROJECT CRATE EXPECTATIONS</span>
       <h1>NEEDLE DROP</h1>
       <p>Musical archaeology conducted at an unsafe volume.</p>
-      ${playerCountMarkup(state.players.length)}
+      ${playerCountMarkup(state.players.length, session)}
+      ${crateFormatsMarkup(state.players.length, session)}
       ${rulesMarkup(isParty)}
     </section>
     ${playersMarkup(state)}

--- a/src/modes/needle-drop/services/profileStore.js
+++ b/src/modes/needle-drop/services/profileStore.js
@@ -3,6 +3,7 @@ const STORAGE_KEY = 'jeoparody.needle-drop.profile.v1';
 const EMPTY_PROFILE = Object.freeze({
   bestScore: 0,
   completedRuns: 0,
+  bestScores: Object.freeze({}),
 });
 
 export class ProfileStore {
@@ -19,20 +20,31 @@ export class ProfileStore {
       const value = JSON.parse(this.storage?.getItem(STORAGE_KEY) || 'null');
       if (!value || typeof value !== 'object') return { ...EMPTY_PROFILE };
 
-      return {
-        bestScore: Math.max(0, Number(value.bestScore) || 0),
-        completedRuns: Math.max(0, Number(value.completedRuns) || 0),
-      };
+      const bestScore = Math.max(0, Number(value.bestScore) || 0);
+      const bestScores = Object.fromEntries(
+        Object.entries(value.bestScores || {})
+          .filter(([key]) => ['quick', 'side-a', 'full'].includes(key))
+          .map(([key, score]) => [key, Math.max(0, Number(score) || 0)]),
+      );
+      if (!Object.keys(bestScores).length && bestScore) bestScores.full = bestScore;
+
+      return { bestScore, completedRuns: Math.max(0, Number(value.completedRuns) || 0), bestScores };
     } catch {
       return { ...EMPTY_PROFILE };
     }
   }
 
-  recordCompletedScore(score) {
+  recordCompletedScore(score, formatId = 'full') {
     const current = this.read();
+    const safeScore = Math.max(0, Number(score) || 0);
+    const safeFormat = ['quick', 'side-a', 'full'].includes(formatId) ? formatId : 'full';
     const next = {
-      bestScore: Math.max(current.bestScore, Math.max(0, Number(score) || 0)),
+      bestScore: Math.max(current.bestScore, safeScore),
       completedRuns: current.completedRuns + 1,
+      bestScores: {
+        ...current.bestScores,
+        [safeFormat]: Math.max(current.bestScores[safeFormat] || 0, safeScore),
+      },
     };
 
     try {

--- a/src/modes/needle-drop/services/sessionRecorder.js
+++ b/src/modes/needle-drop/services/sessionRecorder.js
@@ -1,0 +1,87 @@
+const roundTo = (value, precision = 1) => Number(value.toFixed(precision));
+
+function safeAction(action, next) {
+  return {
+    type: action.type,
+    clueIndex: next.clueIndex,
+    revealIndex: next.revealIndex,
+    playerId: action.playerId || next.lastAttempt?.playerId || null,
+    accepted: action.type === 'SUBMIT_ANSWER' ? Boolean(next.lastAttempt?.accepted) : undefined,
+  };
+}
+
+export class SessionRecorder {
+  constructor({ now = () => Date.now() } = {}) {
+    this.now = now;
+    this.reset();
+  }
+
+  reset() {
+    this.startedAt = this.now();
+    this.endedAt = null;
+    this.events = [];
+  }
+
+  record(action, previous, next) {
+    if (action.type === 'RESTART') {
+      this.reset();
+      return;
+    }
+
+    this.events.push({
+      ...safeAction(action, next),
+      elapsedMs: Math.max(0, this.now() - this.startedAt),
+      replay: action.type === 'PLAY_REVEAL'
+        && previous.listenedRevealIndex >= previous.revealIndex,
+    });
+
+    if (next.phase === 'complete' && previous.phase !== 'complete') this.endedAt = this.now();
+  }
+
+  summarize(state, episode) {
+    const guesses = state.attempts.filter(attempt => !attempt.gaveUp && !attempt.passed);
+    const accepted = guesses.filter(attempt => attempt.accepted);
+    const resolvedAttempts = episode.clues.map(clue => (
+      state.attempts.filter(attempt => attempt.clueId === clue.id).at(-1)
+    )).filter(Boolean);
+    const steals = accepted.filter(attempt => state.attempts.some(candidate => (
+      candidate.clueId === attempt.clueId
+      && candidate.playerId !== attempt.playerId
+      && !candidate.accepted
+      && !candidate.gaveUp
+    ))).length;
+    const revealDepth = resolvedAttempts.length
+      ? resolvedAttempts.reduce((total, attempt) => total + attempt.revealIndex + 1, 0) / resolvedAttempts.length
+      : 0;
+    const finishedAt = this.endedAt || this.now();
+
+    return {
+      completed: state.phase === 'complete',
+      correct: state.correct,
+      clueCount: episode.clues.length,
+      firstDropHits: accepted.filter(attempt => attempt.revealIndex === 0).length,
+      guesses: guesses.length,
+      replays: this.events.filter(event => event.replay).length,
+      revealsBought: this.events.filter(event => event.type === 'MORE_AUDIO').length,
+      buzzes: this.events.filter(event => event.type === 'BUZZ').length,
+      steals,
+      averageReveal: roundTo(revealDepth),
+      durationSeconds: Math.max(0, Math.round((finishedAt - this.startedAt) / 1000)),
+    };
+  }
+}
+
+export function sessionResultText(state, episode, summary) {
+  const session = episode.session || {};
+  const score = state.players.length === 1
+    ? state.score
+    : Math.max(...state.players.map(player => player.score));
+  const lines = [
+    `NEEDLE DROP — ${session.formatLabel || 'Crate'}`,
+    `${summary.correct}/${summary.clueCount} records · ${score.toLocaleString()} pts`,
+    `${summary.firstDropHits} first-drop hits · ${summary.replays} replays · ${summary.revealsBought} reveals bought`,
+  ];
+  if (state.players.length > 1) lines.push(`${summary.steals} steals · ${summary.buzzes} buzzes`);
+  lines.push(`Crate ${session.seed || 'original'} · Project Crate Expectations`);
+  return lines.join('\n');
+}

--- a/src/modes/needle-drop/styles.css
+++ b/src/modes/needle-drop/styles.css
@@ -176,6 +176,45 @@ summary:focus-visible,
   color: #07110f;
 }
 
+.crate-formats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.45rem;
+  width: min(560px, 100%);
+  margin: 0.65rem auto 0;
+}
+
+.crate-formats a {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #ffffff18;
+  border-radius: 8px;
+  background: #090b1280;
+  color: #aaa6b3;
+  text-decoration: none;
+}
+
+.crate-formats strong {
+  color: #e8e1d4;
+  font: 700 0.68rem ui-monospace, monospace;
+}
+
+.crate-formats small {
+  color: #777482;
+  font: 500 0.58rem ui-monospace, monospace;
+}
+
+.crate-formats a:hover,
+.crate-formats a:focus-visible,
+.crate-formats a[aria-current="page"] {
+  border-color: var(--accent-2);
+}
+
+.crate-formats a[aria-current="page"] {
+  box-shadow: inset 0 -3px var(--accent-2);
+}
+
 .rules {
   width: min(620px, 100%);
   margin: 0.9rem auto 0;
@@ -689,8 +728,78 @@ summary:focus-visible,
   font: 800 1rem ui-monospace, monospace;
 }
 
-.finale button {
-  margin: 2rem auto 0;
+.session-receipt {
+  width: min(700px, 100%);
+  margin: 1.6rem auto 0;
+  padding: 1.1rem;
+  border: 1px dashed #ffffff2e;
+  background: #090b12;
+}
+
+.session-receipt dl {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  margin: 0.8rem 0;
+}
+
+.session-receipt dl div {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.65rem;
+  border: 1px solid #ffffff12;
+}
+
+.session-receipt dt,
+.session-receipt > p:last-child {
+  color: #777482;
+  font: 500 0.6rem / 1.4 ui-monospace, monospace;
+}
+
+.session-receipt dd {
+  margin: 0;
+  color: var(--accent-2);
+  font: 800 1.25rem ui-monospace, monospace;
+}
+
+.finale__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+  margin-top: 1.5rem;
+}
+
+.finale__actions button,
+.finale__actions a {
+  display: grid;
+  place-items: center;
+  min-height: 50px;
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border: 1px solid #ffffff20;
+  border-radius: 8px;
+  background: var(--accent-2);
+  color: #06100f;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.finale__actions .button--quiet {
+  background: transparent;
+  color: #aaa6b3;
+}
+
+.copy-status {
+  min-height: 1.2rem;
+  color: #aaa6b3;
+  font: 500 0.65rem ui-monospace, monospace;
+}
+
+.copy-field {
+  position: fixed;
+  top: -100vh;
+  left: -100vw;
 }
 
 footer {
@@ -740,6 +849,15 @@ footer {
     gap: 0.55rem;
   }
 
+  .crate-formats {
+    grid-template-columns: 1fr;
+  }
+
+  .crate-formats a {
+    grid-template-columns: 1fr auto;
+    text-align: left;
+  }
+
   .players {
     grid-template-columns: 1fr 1fr;
   }
@@ -774,6 +892,10 @@ footer {
 
   .standings small {
     display: none;
+  }
+
+  .session-receipt dl {
+    grid-template-columns: 1fr 1fr;
   }
 
   footer {

--- a/tests/needle-drop/markup.test.js
+++ b/tests/needle-drop/markup.test.js
@@ -1,5 +1,6 @@
 import { demoEpisode } from '../../src/modes/needle-drop/core/content.js';
 import { createInitialState } from '../../src/modes/needle-drop/core/round.js';
+import { createSessionEpisode } from '../../src/modes/needle-drop/core/session.js';
 import { renderApp } from '../../src/modes/needle-drop/presentation/markup.js';
 
 describe('Needle Drop presentation contract', () => {
@@ -7,11 +8,43 @@ describe('Needle Drop presentation contract', () => {
     const state = createInitialState(demoEpisode, { playerCount: 3 });
     const markup = renderApp(state, demoEpisode, { profile: { bestScore: 0 } });
     expect(markup).toContain('How to play');
-    expect(markup).toContain('href="?players=3" aria-current="page"');
+    expect(markup).toContain('href="?players=3&amp;crate=full&amp;seed=original" aria-current="page"');
+    expect(markup).toContain('Crate length');
+    expect(markup).toContain('Full Crate');
     expect(markup).toContain('Listen before answering');
     expect(markup).toContain('name="answer" autocomplete="off"');
     expect(markup).toContain('disabled');
     expect(markup).toContain('TRACK 1/8');
+  });
+
+  test('renders a quick-format finale receipt and rematch controls', () => {
+    const episode = createSessionEpisode(demoEpisode, { formatId: 'quick', seed: 'crate-42' });
+    const state = {
+      ...createInitialState(episode),
+      phase: 'complete',
+      score: 1000,
+      correct: 1,
+      players: [{ ...createInitialState(episode).players[0], score: 1000, correct: 1 }],
+    };
+    const markup = renderApp(state, episode, {
+      profile: { bestScores: { quick: 1000 } },
+      session: episode.session,
+      sessionSummary: {
+        firstDropHits: 1,
+        guesses: 2,
+        replays: 0,
+        revealsBought: 1,
+        buzzes: 0,
+        steals: 0,
+        averageReveal: 1.3,
+        durationSeconds: 44,
+      },
+      freshCrateUrl: '?players=1&crate=quick&seed=fresh',
+    });
+    expect(markup).toContain('SESSION RECEIPT');
+    expect(markup).toContain('Rematch same crate');
+    expect(markup).toContain('Fresh crate');
+    expect(markup).toContain('FORMAT BEST');
   });
 
   test('escapes authored content at the presentation boundary', () => {

--- a/tests/needle-drop/profileStore.test.js
+++ b/tests/needle-drop/profileStore.test.js
@@ -12,12 +12,29 @@ function createStorage(initialValue) {
 describe('Needle Drop local profile', () => {
   test('keeps the highest completed solo score', () => {
     const store = new ProfileStore(createStorage());
-    expect(store.recordCompletedScore(2200)).toEqual({ bestScore: 2200, completedRuns: 1 });
-    expect(store.recordCompletedScore(1800)).toEqual({ bestScore: 2200, completedRuns: 2 });
+    expect(store.recordCompletedScore(2200, 'quick')).toEqual({
+      bestScore: 2200,
+      completedRuns: 1,
+      bestScores: { quick: 2200 },
+    });
+    expect(store.recordCompletedScore(1800, 'quick')).toEqual({
+      bestScore: 2200,
+      completedRuns: 2,
+      bestScores: { quick: 2200 },
+    });
   });
 
   test('recovers from malformed storage', () => {
     const store = new ProfileStore(createStorage('{definitely not json'));
-    expect(store.read()).toEqual({ bestScore: 0, completedRuns: 0 });
+    expect(store.read()).toEqual({ bestScore: 0, completedRuns: 0, bestScores: {} });
+  });
+
+  test('migrates the 1.2 best score into the full-crate format', () => {
+    const store = new ProfileStore(createStorage(JSON.stringify({ bestScore: 4200, completedRuns: 3 })));
+    expect(store.read()).toEqual({
+      bestScore: 4200,
+      completedRuns: 3,
+      bestScores: { full: 4200 },
+    });
   });
 });

--- a/tests/needle-drop/session.test.js
+++ b/tests/needle-drop/session.test.js
@@ -1,0 +1,59 @@
+import { demoEpisode } from '../../src/modes/needle-drop/core/content.js';
+import {
+  createFreshSeed,
+  createSessionEpisode,
+  createSessionUrl,
+  normalizeCrateFormat,
+  normalizeSeed,
+  seededShuffle,
+} from '../../src/modes/needle-drop/core/session.js';
+import { createInitialState } from '../../src/modes/needle-drop/core/round.js';
+import { SessionRecorder, sessionResultText } from '../../src/modes/needle-drop/services/sessionRecorder.js';
+
+describe('Needle Drop session layer', () => {
+  test('creates bounded formats without mutating the source episode', () => {
+    const quick = createSessionEpisode(demoEpisode, { formatId: 'quick', seed: 'original' });
+    expect(quick.clues).toHaveLength(3);
+    expect(quick.clues[0]).toBe(demoEpisode.clues[0]);
+    expect(demoEpisode.clues).toHaveLength(8);
+    expect(quick.session).toEqual({ formatId: 'quick', formatLabel: 'Quick Hit', seed: 'original' });
+  });
+
+  test('uses a deterministic seed and preserves original order explicitly', () => {
+    const ids = demoEpisode.clues.map(clue => clue.id);
+    expect(seededShuffle(ids, 'original')).toEqual(ids);
+    expect(seededShuffle(ids, 'crate-42')).toEqual(seededShuffle(ids, 'crate-42'));
+    expect(seededShuffle(ids, 'crate-42')).not.toEqual(seededShuffle(ids, 'crate-43'));
+  });
+
+  test('normalizes hostile query values and creates stable session links', () => {
+    expect(normalizeCrateFormat('the-entire-record-store').id).toBe('full');
+    expect(normalizeSeed('  DROP TABLE<script>  ')).toBe('droptablescript');
+    expect(createSessionUrl({ playerCount: 9, formatId: 'quick', seed: 'A B' })).toBe('?players=4&crate=quick&seed=ab');
+    expect(createFreshSeed(0.5)).toHaveLength(7);
+  });
+
+  test('records anonymous play mechanics and produces a shareable receipt', () => {
+    let time = 1000;
+    const recorder = new SessionRecorder({ now: () => time });
+    const episode = createSessionEpisode(demoEpisode, { formatId: 'quick', seed: 'crate-42' });
+    const previous = createInitialState(episode);
+    const listening = { ...previous, phase: 'listening' };
+    time = 1250;
+    recorder.record({ type: 'PLAY_REVEAL' }, previous, listening);
+    const state = {
+      ...listening,
+      phase: 'complete',
+      score: 1000,
+      correct: 1,
+      attempts: [{ clueId: episode.clues[0].id, playerId: 'player-1', accepted: true, revealIndex: 0, points: 1000 }],
+      players: [{ ...listening.players[0], score: 1000, correct: 1 }],
+    };
+    time = 3000;
+    recorder.record({ type: 'NEXT_CLUE' }, listening, state);
+    const summary = recorder.summarize(state, episode);
+    expect(summary).toMatchObject({ completed: true, correct: 1, clueCount: 3, firstDropHits: 1, durationSeconds: 2 });
+    expect(sessionResultText(state, episode, summary)).toContain('Crate crate-42');
+    expect(recorder.events.some(event => Object.hasOwn(event, 'answer'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Outcome

Turns the fixed eight-track demo into a replayable, measurable proving build without introducing another owner of gameplay truth.

## Product slice

- Quick Hit (3), Side A (5), and Full Crate (8) formats
- deterministic seeded clue order with original-order compatibility
- same-crate rematches and fresh-crate links
- format-aware personal bests with 1.2 profile migration
- local session receipts: first-drop hits, guesses, replays, reveals bought, buzzes, steals, average reveal depth, and elapsed time
- copyable result text
- no telemetry leaves the device and the recorder never stores typed answers

## Architecture

- `core/session.js` owns format/seed normalization and immutable session projections
- `core/round.js` remains the sole owner of score, phase, attempts, locks, and progression
- `SessionRecorder` observes accepted reducer transitions only
- presentation receives computed summaries and safe URLs
- complete plan: `docs/NEEDLE_DROP_THIRD_PASS_2026-08-23.md`

## Evidence

- 70/70 repository tests
- 30/30 Needle Drop tests
- zero Needle Drop ESLint errors
- zero CSS lint findings
- eight-clue rights/content validation
- production Vite build
- browser flow: desktop 4P wrong answer → steal → score
- browser flow: 390px mobile layout
- browser flow: complete three-track Quick Hit → finale receipt
- `git diff --check`

## Known repository setting

The legacy branch-based Pages publisher is still enabled at repository level. The canonical Actions deploy must finish last until an owner selects **Settings → Pages → Source: GitHub Actions**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quick Hit, Side A, and Full Crate session formats with shareable seeded sessions.
  * Added deterministic crate ordering and fresh-crate/rematch options.
  * Added session receipts showing results, performance details, and format-specific best scores.
  * Added copyable result summaries and responsive session controls.
  * Added privacy-conscious local session recording without capturing typed answers.

* **Bug Fixes**
  * Migrated existing best scores into the Full Crate format.

* **Tests**
  * Expanded browser and automated coverage for sessions, receipts, sharing, privacy, and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->