### PR TITLE
Needle Drop 1.4: add Show Director and procedural stings

### DIFF
--- a/DEV_JOURNAL.md
+++ b/DEV_JOURNAL.md
@@ -137,6 +137,15 @@ Append entries newest-first immediately below this heading when practical:
 
 ---
 
+### 2026-08-23 — Codex — prove the Needle Drop Show Director boundary
+- **Read/inspected:** the 1.3 deterministic session loop; canonical Stage, host choreography, architecture, ICM, and platform doctrine; profile, recorder, renderer, audio, and browser contracts; and desktop/mobile/finale capture evidence.
+- **Changed:** introduced a sanitized semantic show-event map after accepted reducer transitions; added a deterministic `ShowDirector` that emits restrained captioned host calls and semantic scene requests; added short original procedural stings behind an independent persistent show-sound preference; moved the local session recorder onto the same privacy-safe event spine; and taught the renderer/runtime checks to prove wrong, steal, finale, mute, and reload behavior.
+- **Evidence/tests:** 78/78 repository tests; focused Director/event/audio/profile/markup coverage; zero Needle Drop lint errors; zero CSS lint findings; eight-clue rights validation; production Vite build; and blocking browser runs for desktop four-player steal, 390px mobile, show-sound persistence, and complete Quick Hit finale.
+- **Decisions:** `core/round.js` remains the only gameplay-truth owner. Events contain bounded facts, never typed answers or mutable state. Comedy spends only the host channel in this slice. Every sound cue has visible caption parity, and Web Audio failure cannot block play.
+- **Unresolved:** GitHub Pages still has a repository-level legacy branch publisher enabled; after merge the canonical Actions deploy must finish last until an owner selects **Settings → Pages → Source: GitHub Actions**.
+- **Next lead domino:** attach one small visual Stage consumer—podium reaction or camera emphasis—to the proven semantic scene request, then blind-test room comprehension before considering phone `InputGateway` calibration.
+- **Refs:** `feat/needle-drop-show-director`, `docs/NEEDLE_DROP_SHOW_DIRECTOR_2026-08-23.md`.
+
 ### 2026-08-23 — Codex — make Needle Drop replayable and measurable
 - **Read/inspected:** the deployed 1.2 Needle Drop loop, reducer/presentation/audio/profile boundaries, browser runtime contract, second-pass roadmap, canonical migration doctrine, and mobile/desktop visual evidence.
 - **Changed:** added deterministic Quick Hit / Side A / Full Crate session projections; safe seed/query normalization; same-crate and fresh-crate flows; format-aware personal-best migration; a local-only semantic `SessionRecorder`; finale receipts and copyable result text; expanded responsive presentation; and a complete three-record browser run.

--- a/docs/NEEDLE_DROP_ARCHITECTURE.md
+++ b/docs/NEEDLE_DROP_ARCHITECTURE.md
@@ -16,6 +16,7 @@ Needle Drop is a composable JeoPARODY music-game mode. The proving build asks wh
 6. **A miss is gameplay, not a funeral.** Wrong solo answers unlock the next reveal; wrong party answers lock only that player for the current clip and open a steal. The reducer adjudicates every lockout.
 7. **Persistence is optional.** `ProfileStore` keeps a solo personal best, but storage failure never blocks a round. Scores are not national secrets, despite what the scoreboard implies.
 8. **Sessions are projections, not new truth.** `core/session.js` deterministically selects a cleared clue order from format + seed. `SessionRecorder` observes accepted transitions, redacts typed answers, and computes a local finale receipt without changing reducer state or sending telemetry.
+9. **The show is a semantic consumer.** `core/showEvents.js` converts accepted reducer transitions into sanitized facts. `ShowDirector` maps those facts to deterministic, captioned performances while `StingAudio` realizes optional procedural cues. Neither may mutate round truth.
 
 ```text
 needle-drop.html
@@ -23,13 +24,16 @@ needle-drop.html
       ├─ core/round.js          deterministic truth kernel
       ├─ core/content.js        episode schema, validator, demo
       ├─ core/session.js        deterministic format + seed projection
+      ├─ core/showEvents.js     sanitized semantic event boundary
       ├─ services/audioRuntime.js implementation router
       ├─ services/synthAudio.js procedural demo adapter
       ├─ services/decodedBufferAudio.js integrity-checked asset adapter
       ├─ presentation/markup.js  escaped state-to-view boundary
+      ├─ presentation/showDirector.js deterministic host/stage direction
       ├─ presentation/Waveform.js
       ├─ services/profileStore.js optional local personal best
       ├─ services/sessionRecorder.js privacy-first semantic receipt
+      ├─ services/stingAudio.js optional procedural cue adapter
       └─ styles.css
 ```
 
@@ -47,7 +51,7 @@ needle-drop.html
 }
 ```
 
-Actions are serializable: `PLAY_REVEAL`, `REVEAL_FINISHED`, `AUDIO_FAILED`, `BUZZ`, `MORE_AUDIO`, `SUBMIT_ANSWER`, `PASS`, `GIVE_UP`, `NEXT_CLUE`, and `RESTART`. Episode version plus action log provides deterministic truth replay.
+Actions are serializable: `PLAY_REVEAL`, `REVEAL_FINISHED`, `AUDIO_FAILED`, `BUZZ`, `MORE_AUDIO`, `SUBMIT_ANSWER`, `PASS`, `GIVE_UP`, `NEXT_CLUE`, and `RESTART`. Episode version plus action log provides deterministic truth replay. Presentation receives sanitized `REVEAL_STARTED`, `REVEAL_READY`, `BUZZ`, `CORRECT`, `WRONG`, `ROUND_TRANSITION`, and `WINNER`-class events rather than raw answer text or mutable reducer state.
 
 The important invariant is that `SUBMIT_ANSWER` and `MORE_AUDIO` are rejected until the current reveal has completed. In party mode, `blockedPlayerIds` resets when the room purchases a longer reveal. This gives every reveal its own fair buzz window without requiring timers or network clocks in the truth kernel.
 

--- a/docs/NEEDLE_DROP_SHOW_DIRECTOR_2026-08-23.md
+++ b/docs/NEEDLE_DROP_SHOW_DIRECTOR_2026-08-23.md
@@ -1,0 +1,58 @@
+# Needle Drop — Host & Sting Director vertical slice
+
+**Date:** 2026-08-23
+**Release target:** proving build 1.4
+**Question:** Can one semantic game event produce a deterministic, accessible show performance without contaminating game truth?
+
+## Contract
+
+```text
+accepted reducer transition
+          ↓
+sanitized semantic event
+          ↓
+      ShowDirector
+       ↙       ↘
+captioned call  optional cue command
+                    ↓
+                StingAudio
+```
+
+`core/round.js` remains the sole owner of phase, score, answer acceptance, locks, and progression. The Director receives facts after the reducer accepts an action. It returns a scene, host call, and optional sound cue. Presentation renders the call; a disposable audio adapter realizes the cue.
+
+## Semantic slice
+
+- `REVEAL_STARTED` / `REVEAL_REPLAYED`
+- `REVEAL_READY`
+- `BUZZ`
+- `CORRECT`, including steal context
+- `WRONG` and `PASS`
+- `REVEAL_PURCHASED` / `CLUE_REVEALED`
+- `ROUND_TRANSITION`
+- `WINNER`
+- `AUDIO_ERROR`
+- `SESSION_RESTARTED`
+
+Events contain identifiers and bounded mechanics. They do not contain typed answers or mutable state objects.
+
+## Presentation rules
+
+1. Host lines are selected deterministically from event identity, package, and crate seed.
+2. Comedy occupies the host-performance budget; clue, camera, environment, and lore channels remain quiet in this slice.
+3. Every cue has an equivalent visible caption. Muting cues never removes information.
+4. Show sound persists independently from music playback and scores.
+5. Cues are original procedural tones, short, cancellable, and failure-tolerant.
+6. Scene requests are semantic (`CLUE`, `PLAYER_ANSWER`, `CORRECT`, `WRONG`, `ROUND_TRANSITION`, `WINNER`) so a later host rig, camera, lighting, or set can consume them without touching the reducer.
+
+## Verification gates
+
+- Event serialization never includes submitted answer text.
+- Identical event + state + seed yields an identical performance.
+- A multiplayer steal produces `CORRECT`, a steal cue, and a caption naming the scorer.
+- Audio failure or missing Web Audio never blocks gameplay.
+- Muting stops active cues and survives reload.
+- Desktop, mobile, Quick Hit finale, lint, rights validation, tests, build, and accessibility remain green.
+
+## Next pressure test
+
+Add one deliberately small visual Stage consumer—podium reaction or camera emphasis—for the same semantic events. If it can consume the event without new game-state ownership, the Director boundary has earned another limb. No giant Stage framework will be constructed merely because rectangles can be named.

--- a/scripts/needle-drop-runtime-check.mjs
+++ b/scripts/needle-drop-runtime-check.mjs
@@ -14,6 +14,7 @@ async function stateSnapshot(page) {
     const answer = document.querySelector('#answer');
     const more = document.querySelector('[data-action="more"]');
     const play = document.querySelector('[data-action="play"]');
+    const sound = document.querySelector('[data-action="toggle-sound"]');
     const game = document.querySelector('#game');
     return {
       phase: game?.dataset.phase,
@@ -21,6 +22,8 @@ async function stateSnapshot(page) {
       answerDisabled: Boolean(answer?.disabled),
       moreDisabled: Boolean(more?.disabled),
       playDisabled: Boolean(play?.disabled),
+      scene: game?.dataset.scene,
+      showSound: sound?.getAttribute('aria-pressed'),
       horizontalOverflow: document.documentElement.scrollWidth > window.innerWidth + 2,
     };
   });
@@ -57,6 +60,7 @@ async function runPartyFlow(browser) {
   await page.getByRole('button', { name: 'Lock it' }).click();
   await page.waitForSelector('[data-player-id="player-1"].is-blocked');
   assert((await page.locator('#game').getAttribute('data-phase')) === 'answering', 'wrong answer must keep the steal window open');
+  assert((await page.locator('#game').getAttribute('data-scene')) === 'WRONG', 'wrong answer must request the WRONG show scene');
 
   await page.keyboard.press('2');
   await page.waitForSelector('[data-player-id="player-2"].is-active');
@@ -65,6 +69,8 @@ async function runPartyFlow(browser) {
   await page.waitForSelector('#game[data-phase="resolved"]');
   assert(await page.getByRole('heading', { name: 'Rubber Duck Funk' }).isVisible(), 'correct steal must reveal the record');
   assert((await page.locator('[data-player-id="player-2"] .players__score').textContent()).trim() === '1,000', 'steal winner must receive the points');
+  assert((await page.locator('#game').getAttribute('data-scene')) === 'CORRECT', 'correct steal must request the CORRECT show scene');
+  assert((await page.locator('.director-call').textContent()).includes('Player 2'), 'correct steal must receive a captioned host performance');
 
   await page.screenshot({ path: path.join(OUT_DIR, 'party-steal-result.png'), fullPage: true });
   assert(runtimeErrors.length === 0, `browser emitted runtime errors: ${runtimeErrors.join(' | ')}`);
@@ -80,6 +86,7 @@ async function runMobileLayout(browser) {
   await page.waitForSelector('#game[data-phase="ready"]');
   const snapshot = await stateSnapshot(page);
   assert(!snapshot.horizontalOverflow, 'mobile layout must not overflow horizontally');
+  assert(snapshot.showSound === 'true', 'show sound control must remain available on mobile');
   assert(await page.getByText('How to play').isVisible(), 'mobile onboarding must remain discoverable');
   assert(await page.getByRole('link', { name: '4P' }).getAttribute('aria-current') === 'page', 'active player count must be announced');
   await page.screenshot({ path: path.join(OUT_DIR, 'mobile-ready.png'), fullPage: true });
@@ -99,6 +106,12 @@ async function runQuickCrate(browser) {
   await page.waitForSelector('#game[data-phase="ready"]');
   assert(await page.getByRole('link', { name: /Quick Hit/ }).getAttribute('aria-current') === 'page', 'quick crate must be selected');
   assert((await page.locator('.clue-card__meta').textContent()).includes('TRACK 1/3'), 'quick crate must contain three tracks');
+  const soundControl = page.getByRole('button', { name: 'Show sound on' });
+  await soundControl.click();
+  assert(await page.getByRole('button', { name: 'Show sound off' }).getAttribute('aria-pressed') === 'false', 'show sound must be independently mutable');
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#game[data-phase="ready"]');
+  assert(await page.getByRole('button', { name: 'Show sound off' }).getAttribute('aria-pressed') === 'false', 'show sound preference must persist');
 
   for (const answer of ['Rubber Duck Funk', 'Midnight Pager', 'Municipal Cowbell']) {
     await page.getByRole('button', { name: /Drop the needle/ }).click();
@@ -110,6 +123,7 @@ async function runQuickCrate(browser) {
   }
 
   await page.waitForSelector('#game[data-phase="complete"]');
+  assert((await page.locator('#game').getAttribute('data-scene')) === 'WINNER', 'completed crate must request the WINNER show scene');
   assert(await page.getByText('SESSION RECEIPT').isVisible(), 'completed crate must expose its session receipt');
   assert(await page.getByRole('button', { name: 'Rematch same crate' }).isVisible(), 'finale must offer a deterministic rematch');
   assert(await page.getByRole('link', { name: /Fresh crate/ }).isVisible(), 'finale must offer a new seed');

--- a/src/modes/needle-drop/core/content.js
+++ b/src/modes/needle-drop/core/content.js
@@ -27,7 +27,7 @@ const synth = sequence => ({ kind: 'synth', sequence });
 
 export const demoEpisode = Object.freeze({
   schemaVersion: 1,
-  packageVersion: '1.3.0',
+  packageVersion: '1.4.0',
   id: 'nd-demo-001',
   title: 'The Unlicensed Basement Tapes',
   description: 'Eight original musical families. No catalog lawyers were awakened.',

--- a/src/modes/needle-drop/core/showEvents.js
+++ b/src/modes/needle-drop/core/showEvents.js
@@ -1,0 +1,81 @@
+export const SHOW_EVENTS = Object.freeze({
+  REVEAL_STARTED: 'REVEAL_STARTED',
+  REVEAL_REPLAYED: 'REVEAL_REPLAYED',
+  REVEAL_READY: 'REVEAL_READY',
+  BUZZ: 'BUZZ',
+  CORRECT: 'CORRECT',
+  WRONG: 'WRONG',
+  PASS: 'PASS',
+  REVEAL_PURCHASED: 'REVEAL_PURCHASED',
+  CLUE_REVEALED: 'CLUE_REVEALED',
+  ROUND_TRANSITION: 'ROUND_TRANSITION',
+  WINNER: 'WINNER',
+  AUDIO_ERROR: 'AUDIO_ERROR',
+  SESSION_RESTARTED: 'SESSION_RESTARTED',
+});
+
+function baseEvent(type, next, episode) {
+  const clue = episode.clues[next.clueIndex];
+  return {
+    type,
+    episodeId: episode.id,
+    packageVersion: episode.packageVersion,
+    clueId: clue?.id || null,
+    clueIndex: next.clueIndex,
+    revealIndex: next.revealIndex,
+  };
+}
+
+export function createShowEvent(action, previous, next, episode) {
+  let type;
+  switch (action.type) {
+    case 'PLAY_REVEAL':
+      type = previous.listenedRevealIndex >= previous.revealIndex
+        ? SHOW_EVENTS.REVEAL_REPLAYED
+        : SHOW_EVENTS.REVEAL_STARTED;
+      break;
+    case 'REVEAL_FINISHED':
+      type = SHOW_EVENTS.REVEAL_READY;
+      break;
+    case 'BUZZ':
+      type = SHOW_EVENTS.BUZZ;
+      break;
+    case 'SUBMIT_ANSWER':
+      type = next.lastAttempt?.accepted ? SHOW_EVENTS.CORRECT : SHOW_EVENTS.WRONG;
+      break;
+    case 'PASS':
+      type = SHOW_EVENTS.PASS;
+      break;
+    case 'MORE_AUDIO':
+      type = SHOW_EVENTS.REVEAL_PURCHASED;
+      break;
+    case 'GIVE_UP':
+      type = SHOW_EVENTS.CLUE_REVEALED;
+      break;
+    case 'NEXT_CLUE':
+      type = next.phase === 'complete' ? SHOW_EVENTS.WINNER : SHOW_EVENTS.ROUND_TRANSITION;
+      break;
+    case 'AUDIO_FAILED':
+      type = SHOW_EVENTS.AUDIO_ERROR;
+      break;
+    case 'RESTART':
+      type = SHOW_EVENTS.SESSION_RESTARTED;
+      break;
+    default:
+      return null;
+  }
+
+  const event = baseEvent(type, next, episode);
+  const playerId = action.playerId || next.lastAttempt?.playerId || previous.activePlayerId || null;
+  if (playerId) event.playerId = playerId;
+  if (next.lastAttempt?.points) event.points = next.lastAttempt.points;
+  if (type === SHOW_EVENTS.CORRECT) {
+    event.isSteal = previous.attempts.some(attempt => (
+      attempt.clueId === event.clueId
+      && attempt.playerId !== event.playerId
+      && !attempt.accepted
+    ));
+  }
+  if (type === SHOW_EVENTS.AUDIO_ERROR) event.message = next.audioError;
+  return Object.freeze(event);
+}

--- a/src/modes/needle-drop/main.js
+++ b/src/modes/needle-drop/main.js
@@ -3,11 +3,14 @@ import { demoEpisode, validateEpisode } from './core/content.js';
 import { playerForKey } from './core/party.js';
 import { createInitialState, reduceRound, ROUND_PHASES } from './core/round.js';
 import { createFreshSeed, createSessionEpisode, createSessionUrl } from './core/session.js';
+import { createShowEvent } from './core/showEvents.js';
 import { renderApp } from './presentation/markup.js';
+import { ShowDirector, SHOW_SCENES } from './presentation/showDirector.js';
 import { Waveform } from './presentation/Waveform.js';
 import { AudioRuntime } from './services/audioRuntime.js';
 import { ProfileStore } from './services/profileStore.js';
 import { SessionRecorder, sessionResultText } from './services/sessionRecorder.js';
+import { StingAudio } from './services/stingAudio.js';
 
 const errors = validateEpisode(demoEpisode);
 if (errors.length) throw new Error(`Needle Drop content invalid:\n${errors.join('\n')}`);
@@ -37,11 +40,18 @@ let playbackToken = 0;
 let isNewBest = false;
 let sessionSummary = null;
 let copyStatus = '';
+let performance = null;
 const sessionRecorder = new SessionRecorder();
+const stingAudio = new StingAudio({ enabled: profile.settings.showSound });
+const showDirector = new ShowDirector({
+  audio: stingAudio,
+  onPerformance: nextPerformance => { performance = nextPerformance; },
+});
 
-function emit(name, detail = {}) {
-  window.dispatchEvent(new CustomEvent(`needle-drop:${name}`, {
-    detail: { ...detail, state },
+function emitShowEvent(event) {
+  if (!event) return;
+  window.dispatchEvent(new CustomEvent('needle-drop:event', {
+    detail: { event, performance },
   }));
 }
 
@@ -49,6 +59,10 @@ function focusAfter(actionType) {
   window.queueMicrotask(() => {
     if (actionType === 'COPY_RESULT') {
       document.querySelector('[data-action="copy-result"]')?.focus();
+      return;
+    }
+    if (actionType === 'TOGGLE_SOUND') {
+      document.querySelector('[data-action="toggle-sound"]')?.focus();
       return;
     }
     if (state.phase === ROUND_PHASES.COMPLETE) {
@@ -84,6 +98,8 @@ function render(actionType) {
     sessionSummary,
     freshCrateUrl,
     copyStatus,
+    performance,
+    showSoundEnabled: profile.settings.showSound,
   });
 
   const canvas = document.querySelector('#waveform');
@@ -102,8 +118,9 @@ function dispatch(action) {
   const next = reduceRound(state, action, episode);
   if (next === previous) return false;
 
+  const showEvent = createShowEvent(action, previous, next, episode);
   state = next;
-  sessionRecorder.record(action, previous, next);
+  sessionRecorder.record(showEvent, previous, next);
   if (state.phase === ROUND_PHASES.COMPLETE && previous.phase !== ROUND_PHASES.COMPLETE) {
     sessionSummary = sessionRecorder.summarize(state, episode);
     if (state.players.length === 1) {
@@ -118,7 +135,8 @@ function dispatch(action) {
     copyStatus = '';
   }
 
-  emit(action.type.toLowerCase(), { action, previous });
+  showDirector.perform(showEvent, state, episode);
+  emitShowEvent(showEvent);
   render(action.type);
   return true;
 }
@@ -138,9 +156,22 @@ async function playCurrentReveal() {
   } catch (error) {
     if (token !== playbackToken) return;
     const message = error instanceof Error ? error.message : 'Unknown playback error';
-    emit('audio_error', { error: message, clueId: clue.id, revealIndex: state.revealIndex });
     dispatch({ type: 'AUDIO_FAILED', message });
   }
+}
+
+function toggleShowSound() {
+  const enabled = !profile.settings.showSound;
+  profile = profileStore.setShowSound(enabled);
+  stingAudio.setEnabled(enabled);
+  performance = {
+    scene: state.phase === ROUND_PHASES.COMPLETE ? SHOW_SCENES.WINNER : SHOW_SCENES.CLUE,
+    cue: null,
+    call: enabled
+      ? 'Show sound on. The tiny orchestra has been released on its own recognizance.'
+      : 'Show sound off. Captions remain on duty and have requested better chairs.',
+  };
+  render('TOGGLE_SOUND');
 }
 
 async function copySessionResult() {
@@ -170,6 +201,7 @@ async function copySessionResult() {
 function stopPlayback() {
   playbackToken += 1;
   audio.stop();
+  showDirector.dispose();
 }
 
 app.addEventListener('click', event => {
@@ -199,6 +231,9 @@ app.addEventListener('click', event => {
       break;
     case 'copy-result':
       copySessionResult();
+      break;
+    case 'toggle-sound':
+      toggleShowSound();
       break;
     default:
       break;

--- a/src/modes/needle-drop/presentation/markup.js
+++ b/src/modes/needle-drop/presentation/markup.js
@@ -57,7 +57,8 @@ function playersMarkup(state) {
   </section>`;
 }
 
-function hostMessage(state, clue) {
+function hostMessage(state, clue, performance) {
+  if (performance?.call) return performance.call;
   if (state.audioError) return `Audio hiccup: ${state.audioError}`;
   if (state.phase === ROUND_PHASES.READY) {
     return state.revealIndex === 0
@@ -109,7 +110,13 @@ function lineageMarkup(clue) {
   <blockquote class="liner-note">“${escapeHtml(clue.linerNote)}”</blockquote>`;
 }
 
-function resultMarkup(state, episode, clue) {
+function directorCallMarkup(performance) {
+  return performance?.call
+    ? `<p class="director-call">HOST BOOTH: ${escapeHtml(performance.call)}</p>`
+    : '';
+}
+
+function resultMarkup(state, episode, clue, options) {
   const accepted = state.result.accepted;
   const player = state.players.find(item => item.id === state.result.playerId);
   const attemptCount = state.attempts.filter(attempt => attempt.clueId === clue.id && !attempt.gaveUp).length;
@@ -126,14 +133,15 @@ function resultMarkup(state, episode, clue) {
       <h2 id="result-heading" tabindex="-1">${escapeHtml(clue.title)}</h2>
       <p>${escapeHtml(clue.artist)}</p>
       <strong>${escapeHtml(scoreLine)}</strong>
+      ${directorCallMarkup(options.performance)}
     </section>
     ${lineageMarkup(clue)}
     <button type="button" class="next" data-action="next">${state.clueIndex === episode.clues.length - 1 ? 'Close the crate' : 'Next record'} →</button>
   </section>`;
 }
 
-function roundMarkup(state, episode, clue, reveal) {
-  if (state.phase === ROUND_PHASES.RESOLVED) return resultMarkup(state, episode, clue);
+function roundMarkup(state, episode, clue, reveal, options) {
+  if (state.phase === ROUND_PHASES.RESOLVED) return resultMarkup(state, episode, clue, options);
 
   const heardCurrentReveal = state.listenedRevealIndex >= state.revealIndex;
   const activePlayer = state.players.find(player => player.id === state.activePlayerId);
@@ -169,7 +177,7 @@ function roundMarkup(state, episode, clue, reveal) {
         <span>${escapeHtml(item.label)}</span><strong>${item.duration}s</strong><small>${item.points} pts</small>
       </div>`).join('')}
     </div>
-    <p class="host-call ${state.audioError ? 'host-call--error' : ''}" role="status" aria-live="polite">${escapeHtml(hostMessage(state, clue))}</p>
+    <p class="host-call ${state.audioError ? 'host-call--error' : ''}" role="status" aria-live="polite">${escapeHtml(hostMessage(state, clue, options.performance))}</p>
     ${missMarkup(state)}
     <form id="answer-form" class="answer">
       <label for="answer">${escapeHtml(answerLabel)}</label>
@@ -218,6 +226,7 @@ function finaleMarkup(state, episode, profile, isNewBest, options) {
   return `<section class="finale">
     <p class="eyebrow">CRATE CLOSED</p>
     <h2 id="finale-heading" tabindex="-1">${escapeHtml(title)}</h2>
+    ${directorCallMarkup(options.performance)}
     <p>${escapeHtml(options.session.formatLabel)} · crate <code>${escapeHtml(options.session.seed)}</code></p>
     <p>${formatPoints(state.score)} room points. The waveform has declined to comment.</p>
     ${state.players.length === 1 ? `<p class="personal-best ${isNewBest ? 'is-new' : ''}">${isNewBest ? 'NEW FORMAT BEST' : 'FORMAT BEST'} <strong>${formatPoints(formatBest)}</strong></p>` : ''}
@@ -250,11 +259,12 @@ export function renderApp(state, episode, options = {}) {
     : { label: 'STREAK', value: state.players[0]?.streak || 0 };
   const body = complete
     ? finaleMarkup(state, episode, profile, isNewBest, { ...options, session })
-    : roundMarkup(state, episode, clue, reveal);
+    : roundMarkup(state, episode, clue, reveal, options);
 
-  return `<main id="game" class="stage" data-phase="${state.phase}" data-reveal-index="${state.revealIndex}" style="--accent:${clue?.palette?.[0] || '#ff3f81'};--accent-2:${clue?.palette?.[1] || '#00d7d7'}">
+  return `<main id="game" class="stage" data-phase="${state.phase}" data-scene="${escapeHtml(options.performance?.scene || 'CLUE')}" data-reveal-index="${state.revealIndex}" style="--accent:${clue?.palette?.[0] || '#ff3f81'};--accent-2:${clue?.palette?.[1] || '#00d7d7'}">
     <header class="show-header">
       <a href="./" class="show-header__universe">JEO<span>PARODY</span> / MUSIC DISTRICT</a>
+      <button type="button" class="show-header__sound" data-action="toggle-sound" aria-pressed="${options.showSoundEnabled !== false}" aria-label="Show sound ${options.showSoundEnabled !== false ? 'on' : 'off'}"><span>SHOW SOUND</span><strong>${options.showSoundEnabled !== false ? 'ON' : 'OFF'}</strong></button>
       <div class="show-header__score"><span>${isParty ? 'ROOM TOTAL' : 'SCORE'}</span><strong>${formatPoints(state.score)}</strong></div>
       <div class="show-header__streak"><span>${secondaryMetric.label}</span><strong>${secondaryMetric.value}</strong></div>
     </header>

--- a/src/modes/needle-drop/presentation/showDirector.js
+++ b/src/modes/needle-drop/presentation/showDirector.js
@@ -1,0 +1,133 @@
+import { rankPlayers } from '../core/party.js';
+import { SHOW_EVENTS } from '../core/showEvents.js';
+
+export const SHOW_SCENES = Object.freeze({
+  CLUE: 'CLUE',
+  PLAYER_ANSWER: 'PLAYER_ANSWER',
+  CORRECT: 'CORRECT',
+  WRONG: 'WRONG',
+  ROUND_TRANSITION: 'ROUND_TRANSITION',
+  WINNER: 'WINNER',
+});
+
+const LINES = Object.freeze({
+  buzz: [
+    name => `${name} has seized the microphone. History has lowered its deductible.`,
+    name => `${name} is on mic. Confidence has entered without a warrant.`,
+  ],
+  correct: [
+    name => `Correct. The crate recognizes ${name} as a person of suspicious competence.`,
+    name => `${name} got it. The record label has reluctantly updated its files.`,
+  ],
+  steal: [
+    name => `${name} steals it. Ownership changed faster than a streaming catalog.`,
+    name => `${name} takes the steal. The previous answer is now listed as a former tenant.`,
+  ],
+  wrong: [
+    name => `${name} misses. The confidence, however, was magnificently unionized.`,
+    name => `The label says no, ${name}. It has hired a very small attorney.`,
+  ],
+  pass: [
+    name => `${name} passes. The microphone has been returned without a receipt.`,
+    name => `${name} releases the mic back into the wild. Steal window open.`,
+  ],
+  reveal: [
+    duration => `${duration} seconds now. The mystery is losing clothing but retains counsel.`,
+    duration => `${duration} seconds. The points are thinner; the plot is slightly less employed.`,
+  ],
+  giveUp: [
+    () => 'The crate opens voluntarily. Dignity may be collected near the exit.',
+    () => 'Answer revealed. The room and the record have agreed to see other people.',
+  ],
+  winner: [
+    name => `${name} wins the crate. Please remain calm while the confetti files a permit.`,
+    name => `${name} takes the crate. Accounting has been asked to stop dancing.`,
+  ],
+  tie: [
+    () => 'The crate declares a tie. Shared custody begins every other weekend.',
+    () => 'A tie. The trophy has been advised to remain emotionally neutral.',
+  ],
+});
+
+function stableIndex(value, length) {
+  let hash = 0;
+  for (const character of value) hash = Math.imul(31, hash) + character.charCodeAt(0) | 0;
+  return Math.abs(hash) % length;
+}
+
+function line(group, key, value) {
+  const choices = LINES[group];
+  return choices[stableIndex(key, choices.length)](value);
+}
+
+function playerName(state, playerId) {
+  return state.players.find(player => player.id === playerId)?.name || 'The room';
+}
+
+export function performanceForEvent(event, state, episode) {
+  if (!event) return null;
+  const key = `${episode.session?.seed || episode.id}:${event.clueId}:${event.type}:${event.playerId || ''}`;
+  const name = playerName(state, event.playerId);
+
+  switch (event.type) {
+    case SHOW_EVENTS.REVEAL_STARTED:
+      return { scene: SHOW_SCENES.CLUE, cue: 'needle', call: 'Needle down. Shazam remains outside with security.' };
+    case SHOW_EVENTS.REVEAL_REPLAYED:
+      return { scene: SHOW_SCENES.CLUE, cue: 'replay', call: 'Replaying the evidence. The waveform has requested representation.' };
+    case SHOW_EVENTS.REVEAL_READY:
+      return { scene: SHOW_SCENES.PLAYER_ANSWER, cue: null, call: state.players.length > 1 ? 'Buzzers open. The fastest eligible panic wins.' : 'Lock an answer, replay, or purchase a larger piece of the crime scene.' };
+    case SHOW_EVENTS.BUZZ:
+      return { scene: SHOW_SCENES.PLAYER_ANSWER, cue: 'buzz', call: line('buzz', key, name) };
+    case SHOW_EVENTS.CORRECT:
+      return {
+        scene: SHOW_SCENES.CORRECT,
+        cue: event.isSteal ? 'steal' : 'correct',
+        call: line(event.isSteal ? 'steal' : 'correct', key, name),
+      };
+    case SHOW_EVENTS.WRONG:
+      return { scene: SHOW_SCENES.WRONG, cue: 'wrong', call: line('wrong', key, name) };
+    case SHOW_EVENTS.PASS:
+      return { scene: SHOW_SCENES.WRONG, cue: 'pass', call: line('pass', key, name) };
+    case SHOW_EVENTS.REVEAL_PURCHASED: {
+      const duration = episode.clues[event.clueIndex].reveals[event.revealIndex].duration;
+      return { scene: SHOW_SCENES.ROUND_TRANSITION, cue: 'reveal', call: line('reveal', key, duration) };
+    }
+    case SHOW_EVENTS.CLUE_REVEALED:
+      return { scene: SHOW_SCENES.WRONG, cue: 'reveal-answer', call: line('giveUp', key) };
+    case SHOW_EVENTS.ROUND_TRANSITION:
+      return { scene: SHOW_SCENES.ROUND_TRANSITION, cue: 'transition', call: 'Next record. The turntable denies any pattern of misconduct.' };
+    case SHOW_EVENTS.WINNER: {
+      const ranked = rankPlayers(state.players);
+      const winners = ranked.filter(player => player.score === ranked[0]?.score);
+      const call = winners.length > 1
+        ? line('tie', key)
+        : line('winner', key, winners[0]?.name || 'The room');
+      return { scene: SHOW_SCENES.WINNER, cue: 'winner', call };
+    }
+    case SHOW_EVENTS.AUDIO_ERROR:
+      return { scene: SHOW_SCENES.CLUE, cue: null, call: `Audio booth report: ${event.message}` };
+    case SHOW_EVENTS.SESSION_RESTARTED:
+      return { scene: SHOW_SCENES.CLUE, cue: 'transition', call: 'Same crate, new alibi. Needle armed.' };
+    default:
+      return null;
+  }
+}
+
+export class ShowDirector {
+  constructor({ audio, onPerformance = () => {} } = {}) {
+    this.audio = audio;
+    this.onPerformance = onPerformance;
+  }
+
+  perform(event, state, episode) {
+    const performance = performanceForEvent(event, state, episode);
+    if (!performance) return null;
+    this.onPerformance(performance);
+    if (performance.cue) void this.audio?.play(performance.cue);
+    return performance;
+  }
+
+  dispose() {
+    this.audio?.stop();
+  }
+}

--- a/src/modes/needle-drop/services/profileStore.js
+++ b/src/modes/needle-drop/services/profileStore.js
@@ -4,6 +4,7 @@ const EMPTY_PROFILE = Object.freeze({
   bestScore: 0,
   completedRuns: 0,
   bestScores: Object.freeze({}),
+  settings: Object.freeze({ showSound: true }),
 });
 
 export class ProfileStore {
@@ -28,7 +29,12 @@ export class ProfileStore {
       );
       if (!Object.keys(bestScores).length && bestScore) bestScores.full = bestScore;
 
-      return { bestScore, completedRuns: Math.max(0, Number(value.completedRuns) || 0), bestScores };
+      return {
+        bestScore,
+        completedRuns: Math.max(0, Number(value.completedRuns) || 0),
+        bestScores,
+        settings: { showSound: value.settings?.showSound !== false },
+      };
     } catch {
       return { ...EMPTY_PROFILE };
     }
@@ -45,14 +51,25 @@ export class ProfileStore {
         ...current.bestScores,
         [safeFormat]: Math.max(current.bestScores[safeFormat] || 0, safeScore),
       },
+      settings: current.settings,
     };
 
+    this.write(next);
+    return next;
+  }
+
+  setShowSound(showSound) {
+    const current = this.read();
+    const next = { ...current, settings: { ...current.settings, showSound: Boolean(showSound) } };
+    this.write(next);
+    return next;
+  }
+
+  write(profile) {
     try {
-      this.storage?.setItem(STORAGE_KEY, JSON.stringify(next));
+      this.storage?.setItem(STORAGE_KEY, JSON.stringify(profile));
     } catch {
       // Storage can be unavailable in private or embedded contexts. The game remains playable.
     }
-
-    return next;
   }
 }

--- a/src/modes/needle-drop/services/sessionRecorder.js
+++ b/src/modes/needle-drop/services/sessionRecorder.js
@@ -1,12 +1,15 @@
+import { SHOW_EVENTS } from '../core/showEvents.js';
+
 const roundTo = (value, precision = 1) => Number(value.toFixed(precision));
 
-function safeAction(action, next) {
+function safeEvent(event) {
   return {
-    type: action.type,
-    clueIndex: next.clueIndex,
-    revealIndex: next.revealIndex,
-    playerId: action.playerId || next.lastAttempt?.playerId || null,
-    accepted: action.type === 'SUBMIT_ANSWER' ? Boolean(next.lastAttempt?.accepted) : undefined,
+    type: event.type,
+    clueId: event.clueId,
+    clueIndex: event.clueIndex,
+    revealIndex: event.revealIndex,
+    playerId: event.playerId || null,
+    isSteal: Boolean(event.isSteal),
   };
 }
 
@@ -22,17 +25,16 @@ export class SessionRecorder {
     this.events = [];
   }
 
-  record(action, previous, next) {
-    if (action.type === 'RESTART') {
+  record(event, previous, next) {
+    if (!event) return;
+    if (event.type === SHOW_EVENTS.SESSION_RESTARTED) {
       this.reset();
       return;
     }
 
     this.events.push({
-      ...safeAction(action, next),
+      ...safeEvent(event),
       elapsedMs: Math.max(0, this.now() - this.startedAt),
-      replay: action.type === 'PLAY_REVEAL'
-        && previous.listenedRevealIndex >= previous.revealIndex,
     });
 
     if (next.phase === 'complete' && previous.phase !== 'complete') this.endedAt = this.now();
@@ -61,9 +63,9 @@ export class SessionRecorder {
       clueCount: episode.clues.length,
       firstDropHits: accepted.filter(attempt => attempt.revealIndex === 0).length,
       guesses: guesses.length,
-      replays: this.events.filter(event => event.replay).length,
-      revealsBought: this.events.filter(event => event.type === 'MORE_AUDIO').length,
-      buzzes: this.events.filter(event => event.type === 'BUZZ').length,
+      replays: this.events.filter(event => event.type === SHOW_EVENTS.REVEAL_REPLAYED).length,
+      revealsBought: this.events.filter(event => event.type === SHOW_EVENTS.REVEAL_PURCHASED).length,
+      buzzes: this.events.filter(event => event.type === SHOW_EVENTS.BUZZ).length,
       steals,
       averageReveal: roundTo(revealDepth),
       durationSeconds: Math.max(0, Math.round((finishedAt - this.startedAt) / 1000)),

--- a/src/modes/needle-drop/services/stingAudio.js
+++ b/src/modes/needle-drop/services/stingAudio.js
@@ -1,0 +1,79 @@
+const CUES = Object.freeze({
+  needle: [[110, 0, 0.08, 'square']],
+  replay: [[220, 0, 0.07, 'triangle'], [330, 0.07, 0.07, 'triangle']],
+  buzz: [[660, 0, 0.07, 'square'], [880, 0.075, 0.08, 'square']],
+  correct: [[261.63, 0, 0.11, 'triangle'], [329.63, 0.1, 0.11, 'triangle'], [392, 0.2, 0.18, 'triangle']],
+  steal: [[196, 0, 0.08, 'square'], [392, 0.075, 0.1, 'square'], [523.25, 0.17, 0.18, 'triangle']],
+  wrong: [[220, 0, 0.13, 'sawtooth'], [164.81, 0.12, 0.2, 'sawtooth']],
+  pass: [[293.66, 0, 0.08, 'triangle'], [220, 0.08, 0.12, 'triangle']],
+  reveal: [[146.83, 0, 0.07, 'square'], [196, 0.07, 0.12, 'square']],
+  'reveal-answer': [[196, 0, 0.1, 'triangle'], [146.83, 0.09, 0.16, 'triangle']],
+  transition: [[130.81, 0, 0.06, 'square'], [196, 0.06, 0.08, 'square']],
+  winner: [[261.63, 0, 0.14, 'triangle'], [329.63, 0.12, 0.14, 'triangle'], [392, 0.24, 0.14, 'triangle'], [523.25, 0.36, 0.28, 'triangle']],
+});
+
+export class StingAudio {
+  constructor({ contextFactory, enabled = true, volume = 0.12 } = {}) {
+    this.contextFactory = contextFactory || (() => {
+      const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextClass) throw new Error('Web Audio is unavailable in this browser.');
+      return new AudioContextClass();
+    });
+    this.enabled = enabled;
+    this.volume = Math.max(0, Math.min(0.3, Number(volume) || 0));
+    this.context = null;
+    this.activeNodes = new Set();
+  }
+
+  setEnabled(enabled) {
+    this.enabled = Boolean(enabled);
+    if (!this.enabled) this.stop();
+  }
+
+  getContext() {
+    if (!this.context || this.context.state === 'closed') this.context = this.contextFactory();
+    return this.context;
+  }
+
+  stop() {
+    for (const oscillator of this.activeNodes) {
+      try {
+        oscillator.stop();
+      } catch {
+        // A completed cue has already stopped itself.
+      }
+    }
+    this.activeNodes.clear();
+  }
+
+  async play(cue) {
+    const notes = CUES[cue];
+    if (!this.enabled || !notes) return false;
+
+    try {
+      this.stop();
+      const context = this.getContext();
+      if (context.state === 'suspended') await context.resume();
+      const start = context.currentTime + 0.015;
+
+      for (const [frequency, offset, duration, type] of notes) {
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        const noteStart = start + offset;
+        oscillator.type = type;
+        oscillator.frequency.setValueAtTime(frequency, noteStart);
+        gain.gain.setValueAtTime(0.0001, noteStart);
+        gain.gain.exponentialRampToValueAtTime(this.volume, noteStart + 0.012);
+        gain.gain.exponentialRampToValueAtTime(0.0001, noteStart + duration);
+        oscillator.connect(gain).connect(context.destination);
+        oscillator.start(noteStart);
+        oscillator.stop(noteStart + duration);
+        this.activeNodes.add(oscillator);
+        oscillator.onended = () => this.activeNodes.delete(oscillator);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/modes/needle-drop/styles.css
+++ b/src/modes/needle-drop/styles.css
@@ -104,11 +104,26 @@ summary:focus-visible,
 }
 
 .show-header__score,
-.show-header__streak {
+.show-header__streak,
+.show-header__sound {
   display: grid;
   min-width: 130px;
   padding: 0.75rem 1.5rem;
   border-left: 1px solid #ffffff20;
+}
+
+.show-header__sound {
+  place-content: center;
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 0;
+  background: transparent;
+  color: #fff;
+  text-align: left;
+}
+
+.show-header__sound[aria-pressed="true"] strong {
+  color: var(--accent-2);
 }
 
 .show-header span {
@@ -472,6 +487,24 @@ summary:focus-visible,
   border-color: #ff6b78;
 }
 
+.director-call {
+  margin: 0.8rem 0 0;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid #ffffff14;
+  background: #090b1299;
+  color: #c8c3d0;
+  font: 600 0.68rem / 1.5 ui-monospace, monospace;
+}
+
+.stage[data-scene="CORRECT"] .clue-card,
+.stage[data-scene="WINNER"] .finale {
+  box-shadow: 0 28px 80px #0009, inset 0 0 0 1px var(--accent-2), 0 0 42px color-mix(in srgb, var(--accent-2), transparent 78%);
+}
+
+.stage[data-scene="WRONG"] .clue-card {
+  box-shadow: 0 28px 80px #0009, inset 0 0 0 1px #ff5b6966;
+}
+
 .miss-call {
   margin-top: 0.45rem;
   color: #ffc6cc;
@@ -823,6 +856,16 @@ footer {
     padding: 0 1rem;
   }
 
+  .show-header__sound {
+    min-width: 78px;
+    padding: 0.75rem;
+    text-align: center;
+  }
+
+  .show-header__sound span {
+    display: none;
+  }
+
   .show-header__streak {
     display: none;
   }
@@ -910,7 +953,8 @@ footer {
 
 @media (width <= 440px) {
   .show-header__universe {
-    font-size: 0.65rem;
+    padding: 0 0.65rem;
+    font-size: 0.58rem;
   }
 
   .marquee h1 {

--- a/tests/needle-drop/markup.test.js
+++ b/tests/needle-drop/markup.test.js
@@ -11,10 +11,23 @@ describe('Needle Drop presentation contract', () => {
     expect(markup).toContain('href="?players=3&amp;crate=full&amp;seed=original" aria-current="page"');
     expect(markup).toContain('Crate length');
     expect(markup).toContain('Full Crate');
+    expect(markup).toContain('aria-label="Show sound on"');
     expect(markup).toContain('Listen before answering');
     expect(markup).toContain('name="answer" autocomplete="off"');
     expect(markup).toContain('disabled');
     expect(markup).toContain('TRACK 1/8');
+  });
+
+  test('renders a captioned director performance and sound preference', () => {
+    const state = createInitialState(demoEpisode);
+    const markup = renderApp(state, demoEpisode, {
+      profile: { bestScores: {}, settings: { showSound: false } },
+      showSoundEnabled: false,
+      performance: { scene: 'WRONG', call: '<the booth objects>', cue: 'wrong' },
+    });
+    expect(markup).toContain('data-scene="WRONG"');
+    expect(markup).toContain('aria-label="Show sound off"');
+    expect(markup).toContain('&lt;the booth objects&gt;');
   });
 
   test('renders a quick-format finale receipt and rematch controls', () => {

--- a/tests/needle-drop/profileStore.test.js
+++ b/tests/needle-drop/profileStore.test.js
@@ -16,17 +16,24 @@ describe('Needle Drop local profile', () => {
       bestScore: 2200,
       completedRuns: 1,
       bestScores: { quick: 2200 },
+      settings: { showSound: true },
     });
     expect(store.recordCompletedScore(1800, 'quick')).toEqual({
       bestScore: 2200,
       completedRuns: 2,
       bestScores: { quick: 2200 },
+      settings: { showSound: true },
     });
   });
 
   test('recovers from malformed storage', () => {
     const store = new ProfileStore(createStorage('{definitely not json'));
-    expect(store.read()).toEqual({ bestScore: 0, completedRuns: 0, bestScores: {} });
+    expect(store.read()).toEqual({
+      bestScore: 0,
+      completedRuns: 0,
+      bestScores: {},
+      settings: { showSound: true },
+    });
   });
 
   test('migrates the 1.2 best score into the full-crate format', () => {
@@ -35,6 +42,16 @@ describe('Needle Drop local profile', () => {
       bestScore: 4200,
       completedRuns: 3,
       bestScores: { full: 4200 },
+      settings: { showSound: true },
+    });
+  });
+
+  test('persists show sound independently from scores', () => {
+    const store = new ProfileStore(createStorage());
+    expect(store.setShowSound(false).settings.showSound).toBe(false);
+    expect(store.recordCompletedScore(900, 'quick')).toMatchObject({
+      bestScores: { quick: 900 },
+      settings: { showSound: false },
     });
   });
 });

--- a/tests/needle-drop/session.test.js
+++ b/tests/needle-drop/session.test.js
@@ -8,6 +8,7 @@ import {
   seededShuffle,
 } from '../../src/modes/needle-drop/core/session.js';
 import { createInitialState } from '../../src/modes/needle-drop/core/round.js';
+import { createShowEvent } from '../../src/modes/needle-drop/core/showEvents.js';
 import { SessionRecorder, sessionResultText } from '../../src/modes/needle-drop/services/sessionRecorder.js';
 
 describe('Needle Drop session layer', () => {
@@ -40,7 +41,7 @@ describe('Needle Drop session layer', () => {
     const previous = createInitialState(episode);
     const listening = { ...previous, phase: 'listening' };
     time = 1250;
-    recorder.record({ type: 'PLAY_REVEAL' }, previous, listening);
+    recorder.record(createShowEvent({ type: 'PLAY_REVEAL' }, previous, listening, episode), previous, listening);
     const state = {
       ...listening,
       phase: 'complete',
@@ -50,7 +51,7 @@ describe('Needle Drop session layer', () => {
       players: [{ ...listening.players[0], score: 1000, correct: 1 }],
     };
     time = 3000;
-    recorder.record({ type: 'NEXT_CLUE' }, listening, state);
+    recorder.record(createShowEvent({ type: 'NEXT_CLUE' }, listening, state, episode), listening, state);
     const summary = recorder.summarize(state, episode);
     expect(summary).toMatchObject({ completed: true, correct: 1, clueCount: 3, firstDropHits: 1, durationSeconds: 2 });
     expect(sessionResultText(state, episode, summary)).toContain('Crate crate-42');

--- a/tests/needle-drop/showDirector.test.js
+++ b/tests/needle-drop/showDirector.test.js
@@ -1,0 +1,69 @@
+import { demoEpisode } from '../../src/modes/needle-drop/core/content.js';
+import { createInitialState, reduceRound } from '../../src/modes/needle-drop/core/round.js';
+import { createSessionEpisode } from '../../src/modes/needle-drop/core/session.js';
+import { createShowEvent, SHOW_EVENTS } from '../../src/modes/needle-drop/core/showEvents.js';
+import {
+  performanceForEvent,
+  ShowDirector,
+  SHOW_SCENES,
+} from '../../src/modes/needle-drop/presentation/showDirector.js';
+
+const transition = (state, action, episode) => {
+  const next = reduceRound(state, action, episode);
+  return { next, event: createShowEvent(action, state, next, episode) };
+};
+
+describe('Needle Drop semantic show direction', () => {
+  test('maps a typed answer to a sanitized correct event', () => {
+    const episode = createSessionEpisode(demoEpisode, { formatId: 'quick', seed: 'crate-42' });
+    let state = createInitialState(episode);
+    state = transition(state, { type: 'PLAY_REVEAL' }, episode).next;
+    state = transition(state, { type: 'REVEAL_FINISHED' }, episode).next;
+    const { next, event } = transition(state, { type: 'SUBMIT_ANSWER', answer: episode.clues[0].title }, episode);
+    expect(event).toMatchObject({ type: SHOW_EVENTS.CORRECT, points: 1000, isSteal: false });
+    expect(JSON.stringify(event)).not.toContain(episode.clues[0].title);
+    expect(performanceForEvent(event, next, episode)).toMatchObject({
+      scene: SHOW_SCENES.CORRECT,
+      cue: 'correct',
+    });
+  });
+
+  test('recognizes and performs a multiplayer steal deterministically', () => {
+    const episode = createSessionEpisode(demoEpisode, { formatId: 'quick', seed: 'original' });
+    let state = createInitialState(episode, { playerCount: 2 });
+    state = transition(state, { type: 'PLAY_REVEAL' }, episode).next;
+    state = transition(state, { type: 'REVEAL_FINISHED' }, episode).next;
+    state = transition(state, { type: 'BUZZ', playerId: 'player-1' }, episode).next;
+    state = transition(state, { type: 'SUBMIT_ANSWER', answer: 'wrong' }, episode).next;
+    state = transition(state, { type: 'BUZZ', playerId: 'player-2' }, episode).next;
+    const { next, event } = transition(state, { type: 'SUBMIT_ANSWER', answer: 'Rubber Duck Funk' }, episode);
+    const first = performanceForEvent(event, next, episode);
+    const second = performanceForEvent(event, next, episode);
+    expect(event).toMatchObject({ type: SHOW_EVENTS.CORRECT, playerId: 'player-2', isSteal: true });
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({ scene: SHOW_SCENES.CORRECT, cue: 'steal' });
+    expect(first.call).toContain('Player 2');
+  });
+
+  test('routes one semantic event to caption and audio adapters and disposes cleanly', () => {
+    const audio = { play: jest.fn(() => Promise.resolve(true)), stop: jest.fn() };
+    const onPerformance = jest.fn();
+    const director = new ShowDirector({ audio, onPerformance });
+    const state = createInitialState(demoEpisode, { playerCount: 2 });
+    const event = { type: SHOW_EVENTS.BUZZ, clueId: demoEpisode.clues[0].id, playerId: 'player-1' };
+    const performance = director.perform(event, state, demoEpisode);
+    expect(performance).toMatchObject({ scene: SHOW_SCENES.PLAYER_ANSWER, cue: 'buzz' });
+    expect(onPerformance).toHaveBeenCalledWith(performance);
+    expect(audio.play).toHaveBeenCalledWith('buzz');
+    director.dispose();
+    expect(audio.stop).toHaveBeenCalled();
+  });
+
+  test('directs a tied finale without inventing a winner', () => {
+    const state = { ...createInitialState(demoEpisode, { playerCount: 2 }), phase: 'complete' };
+    const event = { type: SHOW_EVENTS.WINNER, clueId: demoEpisode.clues[0].id };
+    const performance = performanceForEvent(event, state, demoEpisode);
+    expect(performance).toMatchObject({ scene: SHOW_SCENES.WINNER, cue: 'winner' });
+    expect(performance.call.toLowerCase()).toContain('tie');
+  });
+});

--- a/tests/needle-drop/stingAudio.test.js
+++ b/tests/needle-drop/stingAudio.test.js
@@ -1,0 +1,47 @@
+import { StingAudio } from '../../src/modes/needle-drop/services/stingAudio.js';
+
+function createAudioHarness() {
+  const oscillators = [];
+  const context = {
+    state: 'running',
+    currentTime: 10,
+    destination: {},
+    createOscillator: jest.fn(() => {
+      const oscillator = {
+        type: 'sine',
+        frequency: { setValueAtTime: jest.fn() },
+        connect: jest.fn(node => node),
+        start: jest.fn(),
+        stop: jest.fn(),
+        onended: null,
+      };
+      oscillators.push(oscillator);
+      return oscillator;
+    }),
+    createGain: jest.fn(() => ({
+      gain: {
+        setValueAtTime: jest.fn(),
+        exponentialRampToValueAtTime: jest.fn(),
+      },
+      connect: jest.fn(node => node),
+    })),
+  };
+  return { context, oscillators };
+}
+
+describe('Needle Drop procedural sting audio', () => {
+  test('plays known cues and cancels active nodes when muted', async () => {
+    const { context, oscillators } = createAudioHarness();
+    const audio = new StingAudio({ contextFactory: () => context, enabled: true });
+    await expect(audio.play('correct')).resolves.toBe(true);
+    expect(context.createOscillator).toHaveBeenCalledTimes(3);
+    audio.setEnabled(false);
+    expect(oscillators.every(oscillator => oscillator.stop.mock.calls.length > 0)).toBe(true);
+    await expect(audio.play('correct')).resolves.toBe(false);
+  });
+
+  test('fails silently when Web Audio is unavailable', async () => {
+    const audio = new StingAudio({ contextFactory: () => { throw new Error('no speakers'); } });
+    await expect(audio.play('winner')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- Add a sanitized semantic event boundary after accepted game transitions
- Add deterministic host booth performances and semantic scene requests
- Add short original procedural stings with persistent independent mute control
- Move local session metrics onto the privacy-safe event spine
- Prove wrong, steal, finale, mobile, mute, and reload behavior in browser checks

## Verification
- 78/78 Jest tests
- ESLint: no errors
- Stylelint: 0 errors, 0 warnings
- Needle Drop rights/content validation: 8 clues
- Production Vite build
- Browser runtime: four-player steal, 390px mobile, sound persistence, complete Quick Hit finale

Typed answers and mutable state never cross the show-event boundary. `core/round.js` remains the only gameplay-truth owner.