### PR TITLE
Deploy: wire Firebase web config into GitHub Pages build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -60,6 +60,29 @@ jobs:
           fi
 
       - run: npm run build
+
+      - name: Stamp immutable build metadata
+        env:
+          BUILD_SHA: ${{ github.sha }}
+          BUILD_REF: ${{ github.ref }}
+          BUILD_RUN_ID: ${{ github.run_id }}
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const metadata = {
+            gitSha: process.env.BUILD_SHA,
+            gitRef: process.env.BUILD_REF,
+            workflowRunId: process.env.BUILD_RUN_ID,
+            builtAt: new Date().toISOString(),
+          };
+
+          fs.writeFileSync(
+            'dist/build-meta.json',
+            `${JSON.stringify(metadata, null, 2)}\n`,
+          );
+          NODE
+
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:
@@ -71,7 +94,64 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+  verify-live:
+    name: verify-live-pages
+    runs-on: ubuntu-latest
+    needs: deploy
+    env:
+      PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+      EXPECTED_SHA: ${{ github.sha }}
+    steps:
+      - name: Verify published entrypoints and exact commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${PAGE_URL%/}"
+
+          fetch() {
+            local path="$1"
+            local output="$2"
+            curl \
+              --fail \
+              --silent \
+              --show-error \
+              --location \
+              --retry 8 \
+              --retry-delay 2 \
+              --retry-all-errors \
+              --max-time 30 \
+              "$base/$path" \
+              --output "$output"
+          }
+
+          fetch "" /tmp/jeoparody-root.html
+          fetch "needle-drop.html" /tmp/jeoparody-needle-drop.html
+          fetch "head-to-head.html" /tmp/jeoparody-head-to-head.html
+          fetch "build-meta.json" /tmp/jeoparody-build-meta.json
+
+          grep -q '<html' /tmp/jeoparody-root.html
+          grep -q 'head-to-head-app' /tmp/jeoparody-head-to-head.html
+
+          EXPECTED_SHA="$EXPECTED_SHA" node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const metadata = JSON.parse(
+            fs.readFileSync('/tmp/jeoparody-build-meta.json', 'utf8'),
+          );
+
+          if (metadata.gitSha !== process.env.EXPECTED_SHA) {
+            console.error(
+              `Pages commit mismatch: expected ${process.env.EXPECTED_SHA}, received ${metadata.gitSha}`,
+            );
+            process.exit(1);
+          }
+
+          console.log(`Verified live Pages commit ${metadata.gitSha}.`);
+          NODE

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -123,11 +123,11 @@ jobs:
               --silent \
               --show-error \
               --location \
-              --retry 8 \
-              --retry-delay 2 \
+              --retry 12 \
+              --retry-delay 5 \
               --retry-all-errors \
               --max-time 30 \
-              "$base/$path" \
+              "$base/$path?verify=$EXPECTED_SHA" \
               --output "$output"
           }
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,6 +17,16 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Firebase's web configuration is client-visible configuration, not an
+      # authorization secret. Store these as repository Actions variables.
+      # When they are absent, Head-to-Head deliberately builds in local proving mode.
+      VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,6 +36,29 @@ jobs:
       - run: npm ci
       - run: npm run needle-drop:validate
       - run: npm test -- --runInBand
+
+      - name: Report multiplayer deployment mode
+        shell: bash
+        run: |
+          required=(
+            VITE_FIREBASE_API_KEY
+            VITE_FIREBASE_AUTH_DOMAIN
+            VITE_FIREBASE_PROJECT_ID
+            VITE_FIREBASE_APP_ID
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Firebase multiplayer configuration detected; Pages will build the cloud transport."
+          else
+            echo "::notice::Firebase multiplayer configuration is incomplete; Head-to-Head will build in local proving mode. Missing repository variables: ${missing[*]}"
+          fi
+
       - run: npm run build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Outcome

Prepare the canonical GitHub Pages pipeline for Firebase cloud multiplayer **and make deployment verification executable**.

## Firebase build seam

`deploy-pages.yml` maps these **repository Actions variables** into the Vite production build:

- `VITE_FIREBASE_API_KEY`
- `VITE_FIREBASE_AUTH_DOMAIN`
- `VITE_FIREBASE_PROJECT_ID`
- `VITE_FIREBASE_APP_ID`
- `VITE_FIREBASE_STORAGE_BUCKET`
- `VITE_FIREBASE_MESSAGING_SENDER_ID`

The deploy build emits a non-secret notice telling us whether the required Firebase values are present. Missing configuration is not a deployment failure: Head-to-Head intentionally remains in local proving mode until Firebase is activated.

## Exact deployment proof

Every Pages build now stamps `dist/build-meta.json` with:

- exact Git SHA;
- Git ref;
- workflow run ID;
- build timestamp.

After `actions/deploy-pages` finishes, a blocking `verify-live-pages` job fetches the **actual published site** and verifies:

- root page responds;
- `/needle-drop.html` responds;
- `/head-to-head.html` responds and contains the expected app mount;
- `/build-meta.json` reports the exact `${{ github.sha }}` that triggered the deployment.

A green Pages workflow will therefore mean “this precise commit is publicly serving,” not merely “an artifact uploaded successfully.”

## Security boundary

Firebase web config is client-visible configuration, not authorization credentials. Authorization remains Firebase Auth + Firestore Security Rules. No service-account key or privileged Firebase credential is added to the Pages build or public metadata.

## Why this is the next upstream seam

Issue #44 owns the real Firebase/two-device proof. Issue #46 owns the one-time repository Pages Source setting (`GitHub Actions`) that the connected GitHub tool cannot read or mutate. This PR makes both future states observable and removes another code edit from Firebase activation.

Still required outside this PR:

1. ensure Settings → Pages → Source is **GitHub Actions**;
2. select/create the real Firebase project;
3. enable Anonymous Auth;
4. add the repository Actions variables;
5. deploy Firestore rules/indexes/TTL to that Firebase project;
6. run the phone ↔ laptop reconnect proof.

No gameplay behavior changes when the Firebase variables are absent.