### PR TITLE
Refactor: converge Main and Head-to-Head answer judgment

### DIFF
--- a/DEV_JOURNAL.d/2026-08-25T0331-convergence-answer-judgment.md
+++ b/DEV_JOURNAL.d/2026-08-25T0331-convergence-answer-judgment.md
@@ -1,0 +1,9 @@
+# 2026-08-25 03:31 ET — ChatGPT — canonical answer judgment convergence
+
+- **Read/inspected:** current `GameEngine`, Head-to-Head matcher/host, unreachable validation/scoring kernels, August canonical migration strategy, current Jeopardish donor `game-logic.js` and its parity tests, current master plan and architecture.
+- **Changed:** added `src/core/answerJudge.js`; routed Main Game and Head-to-Head correctness through it; retained H2H similarity as diagnostics only; added donor-parity fixtures; added `docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md`.
+- **Evidence/tests:** PR #61 CI run 32821958262 started on exact branch head. New fixtures cover phrasing, diacritics, archive alternates/parentheticals, aliases, plurals, transpositions, safe typos, dangerous near-misses and blanks. Full CI/browser/security proof must be green before merge.
+- **Decisions:** correctness has one shared deterministic owner; presentation/comedy stays downstream; scoring was intentionally not changed in this slice because current production and test-only scoring doctrines conflict and require an explicit product decision.
+- **Unresolved:** converge scoring/clue-value/reveal semantics; slim `GameEngine` external responsibilities; retire displaced validator/matcher fossils after consumers are accounted for; reconcile Episode/Study/host/media/localization dispositions from the capability matrix.
+- **Next lead domino:** finish PR #61, then scoring convergence under #60. Resume Firebase #44 after the bounded convergence stop condition is met.
+- **Refs:** `refactor/canonical-answer-judgment`, PR #61, issue #60, capability matrix above.

--- a/docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md
+++ b/docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md
@@ -1,0 +1,74 @@
+# Convergence 2.0 Capability Matrix
+
+**Status:** ACTIVE RECONCILIATION REGISTER  
+**Date:** 2026-08-25  
+**Owner:** issue #60
+
+This register exists to prevent cleanup from deleting proven behavior or forgotten product intent. It is not permission to wholesale-merge `AlexBaldman/Jeopardish`, abandoned refactors, or speculative stacked systems.
+
+The rule is:
+
+```text
+prove behavior → port onto current ownership → add fixtures → retire donor/duplicate implementation
+```
+
+## Dispositions
+
+- **PORT NOW** — duplicate truth or near-term architectural prerequisite; reconcile before Firebase work continues.
+- **FOCUSED FOLLOW-UP** — proven and valuable, but does not belong in the current truth-convergence slice.
+- **REFERENCE** — preserve design/behavior as donor material; do not port until a real consumer pulls it forward.
+- **RETIRE** — superseded or misleading implementation; preserve history only when provenance is useful.
+
+## Current matrix
+
+| Capability | Donor / evidence | Current jeoPARODY state | Disposition | Why |
+|---|---|---|---|---|
+| Answer judgment | `Jeopardish/game-logic.js` + donor tests | Main, H2H and old validators diverged | **PORT NOW** | Correctness is domain truth. Multiple judges can produce different winners. |
+| Scoring / clue-value / reveal semantics | donor game logic + current `GameEngine` + current `core/scoring.js` tests | Competing production and test-only doctrines | **PORT NOW** | Score is domain truth; dead tests must not guard a second ruleset. |
+| GameEngine responsibility boundaries | current `src/core/GameEngine.js` | Domain transitions mixed with fetching, persistence, achievements and FPS instrumentation | **PORT NOW** | Simplifies the path every future gameplay feature must understand. |
+| Authored Episode/content contract | August migration blueprint / Jeopardish episode work | Not yet a current canonical runtime owner | **FOCUSED FOLLOW-UP** | Strong next product/content primitive after truth convergence; should not block judge/scoring cleanup. |
+| Study pause/resume + learning ledger / review queue | proven Jeopardish Study behavior | Not represented as one current subsystem | **FOCUSED FOLLOW-UP** | Core educational promise; depends on stable clue identity + judgment/scoring events. |
+| HostPack / HostAvatarPack / HostPerformanceDirector | August blueprint / donor host work | Stage/show pieces exist, full contract not current | **FOCUSED FOLLOW-UP** | High product leverage, but presentation must stay downstream of stable truth. |
+| Media preflight / substitution / accessibility | donor media work + current runtime assets | Partial/current behavior distributed | **FOCUSED FOLLOW-UP** | Important release quality; reconcile after core rules and content contract. |
+| Bilingual / localization behavior | donor bilingual work | Not a current canonical runtime boundary | **FOCUSED FOLLOW-UP** | Valuable content-system requirement; should pressure-test Episode/content contract. |
+| Stage semantic presentation contracts | `docs/STAGE_RUNTIME_SYSTEM.md` + donor behavior | Current canonical Stage exists | **REFERENCE** | Preserve and extend through semantic events; do not re-import donor DOM architecture. |
+| Product-event / release proof | donor release gates + current CI/browser evidence | Current repo has stronger CI/runtime proof | **REFERENCE** | Mine missing assertions only; current pipeline owns release truth. |
+| Full Board | August blueprint / donor work | Not current lead path | **REFERENCE** | Later mode once domain/content contracts are stable. |
+| PAO / Memorization integration | current PAO surfaces + broader memory plan | Partial/experimental | **REFERENCE** | Preserve as later learning consumer; do not let it distort current trivia truth kernel. |
+| Couch Party | August blueprint | Not current lead path | **REFERENCE** | Valuable social mode after cloud multiplayer substrate is proven. |
+| Topic Shows / Host Studio / creator tooling | August blueprint | Not current runtime | **REFERENCE** | Product expansion after content + host contracts have stable owners. |
+| Stacked CharacterGenome / Stadium-style speculative systems | donor/speculative branches | Not current canonical requirement | **RETIRE / REFERENCE ONLY** | Do not drag speculative architecture into convergence merely because code exists. |
+| Legacy validator/comedy matcher helpers | current unreachable utility fossils | No production consumers found | **RETIRE AFTER JUDGE PORT** | Presentation/comedy does not belong in correctness truth; salvage copy only if independently valuable. |
+
+## Current convergence sequence
+
+```text
+1 canonical answer judge
+        ↓
+1 explicit scoring contract
+        ↓
+slim GameEngine boundaries
+        ↓
+retire displaced validators / matchers / dead owners
+        ↓
+re-run source reachability
+        ↓
+reconcile Episode + Study as focused follow-ups
+        ↓
+resume Firebase #44
+```
+
+## Stop condition
+
+Convergence 2.0 is not an excuse to remodel the universe.
+
+Stop the current bite when:
+
+1. Main Game and Head-to-Head share one answer-judgment kernel with donor parity fixtures.
+2. Scoring has one explicit current owner or intentionally mode-specific owners with no accidental duplicate doctrine.
+3. `GameEngine` responsibilities are reduced to understandable game-domain orchestration, with externalities behind seams.
+4. The source-reachability inventory is rerun and displaced implementations are retired conservatively.
+5. Every major forgotten capability above has an explicit disposition.
+6. Exact-head CI/browser/security evidence is green.
+
+Then Firebase #44 resumes as the product lead domino.

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -20,6 +20,7 @@ import { eventBus } from '../utils/events.js';
 import { ACTION_TYPES } from '../state/actions.js';
 import { getQuestion } from '../services/api/questionService.js';
 import { store } from '../state/store.js';
+import { compareAnswers } from './answerJudge.js';
 
 // Game constants
 export const GAME_CONFIG = {
@@ -336,67 +337,13 @@ export class GameEngine {
   }
   
   /**
-   * Check if answer is correct using fuzzy matching
+   * Check correctness through the canonical deterministic answer judge.
    * @param {string} userAnswer - User's answer
    * @param {string} correctAnswer - Correct answer
    * @returns {boolean} Whether answer is correct
    */
   checkAnswer(userAnswer, correctAnswer) {
-    if (!userAnswer || !correctAnswer) return false;
-    
-    // Normalize both answers
-    const normalize = (str) =>
-      str.toLowerCase()
-         .trim()
-         .replace(/[^a-z0-9\s]/g, '')
-         .replace(/\s+/g, ' ');
-    
-    const normalizedUser = normalize(userAnswer);
-    const normalizedCorrect = normalize(correctAnswer);
-    
-    // Exact match
-    if (normalizedUser === normalizedCorrect) return true;
-    
-    // Fuzzy matching for partial credit
-    const similarity = this.calculateSimilarity(normalizedUser, normalizedCorrect);
-    return similarity >= 0.8; // 80% similarity threshold
-  }
-  
-  /**
-   * Calculate string similarity using Levenshtein distance
-   * @param {string} str1 - First string
-   * @param {string} str2 - Second string
-   * @returns {number} Similarity score (0-1)
-   */
-  calculateSimilarity(str1, str2) {
-    const matrix = [];
-    
-    for (let i = 0; i <= str2.length; i++) {
-      matrix[i] = [i];
-    }
-    
-    for (let j = 0; j <= str1.length; j++) {
-      matrix[0][j] = j;
-    }
-    
-    for (let i = 1; i <= str2.length; i++) {
-      for (let j = 1; j <= str1.length; j++) {
-        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
-          matrix[i][j] = matrix[i - 1][j - 1];
-        } else {
-          matrix[i][j] = Math.min(
-            matrix[i - 1][j - 1] + 1,
-            matrix[i][j - 1] + 1,
-            matrix[i - 1][j] + 1
-          );
-        }
-      }
-    }
-    
-    const distance = matrix[str2.length][str1.length];
-    const maxLength = Math.max(str1.length, str2.length);
-    
-    return maxLength === 0 ? 1 : 1 - (distance / maxLength);
+    return compareAnswers(userAnswer, correctAnswer);
   }
   
   /**

--- a/src/core/answerJudge.js
+++ b/src/core/answerJudge.js
@@ -1,0 +1,253 @@
+const WHOLE_ANSWER_ALIASES = Object.freeze({
+  unitedstates: ['us', 'usa', 'unitedstatesofamerica'],
+  unitedkingdom: ['uk', 'greatbritain'],
+});
+
+/**
+ * Canonical deterministic answer judgment for jeoPARODY.
+ *
+ * This kernel is adapted from behavior already proven in the Jeopardish donor
+ * runtime. It owns correctness only. UI feedback, comedy, scoring, and mode
+ * authority belong elsewhere.
+ */
+export function normalizeAnswer(answer) {
+  return String(answer || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&/g, ' and ')
+    .replace(/\\/g, '')
+    .trim()
+    .replace(/^(?:what|who|where|when)\s+(?:is|are|was|were)\s+/i, '')
+    .replace(/^what'?s\s+/i, '')
+    .replace(/^(?:or|aka|also known as)\s+/i, '')
+    .replace(/^(?:a|an|the)\s+/i, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function cleanAnswer(answer) {
+  return normalizeAnswer(answer).replace(/\s/g, '');
+}
+
+function addAcceptedAnswer(candidates, seen, answer) {
+  const normalized = normalizeAnswer(answer);
+  const compact = cleanAnswer(answer);
+  if (!compact || seen.has(compact)) return;
+
+  seen.add(compact);
+  candidates.push({ normalized, compact });
+}
+
+function splitAlternates(answer) {
+  const raw = String(answer || '').trim();
+  if (!raw) return [];
+
+  if (/\s+(?:or|aka|also known as)\s+/i.test(raw)) {
+    return raw
+      .replace(/\s*,?\s+(?:or|aka|also known as)\s+/gi, '|')
+      .split(/\s*(?:,|\|)\s*/)
+      .filter(Boolean);
+  }
+
+  if (/[;/|]/.test(raw)) {
+    return raw.split(/\s*[;/|]\s*/).filter(Boolean);
+  }
+
+  return [];
+}
+
+function getAcceptedAnswerCandidates(answer) {
+  const raw = String(answer || '').trim();
+  const candidates = [];
+  const seen = new Set();
+  const parentheticals = Array.from(raw.matchAll(/\(([^)]+)\)/g), (match) => match[1].trim());
+  const withoutParentheticals = raw.replace(/\s*\([^)]*\)/g, ' ').replace(/\s+/g, ' ').trim();
+  const topLevelAlternates = splitAlternates(withoutParentheticals);
+
+  if (topLevelAlternates.length > 0) {
+    topLevelAlternates.forEach((part) => addAcceptedAnswer(candidates, seen, part));
+  } else {
+    addAcceptedAnswer(candidates, seen, withoutParentheticals || raw);
+  }
+
+  let hasAlternativeAnnotation = false;
+  parentheticals.forEach((parenthetical) => {
+    let alternatives = [];
+    const prefixedAlternative = parenthetical.match(/^(?:or|aka|also known as)\s+(.+)$/i);
+    const acceptedAlternative = parenthetical.match(/^(.+?)\s+(?:also\s+)?accepted$/i);
+
+    if (prefixedAlternative) {
+      alternatives = splitAlternates(prefixedAlternative[1]);
+      if (alternatives.length === 0) alternatives = [prefixedAlternative[1]];
+    } else if (acceptedAlternative) {
+      alternatives = splitAlternates(acceptedAlternative[1]);
+      if (alternatives.length === 0) alternatives = [acceptedAlternative[1]];
+    }
+
+    if (alternatives.length > 0) {
+      hasAlternativeAnnotation = true;
+      alternatives.forEach((part) => addAcceptedAnswer(candidates, seen, part));
+    }
+  });
+
+  if (!hasAlternativeAnnotation && parentheticals.length > 0) {
+    addAcceptedAnswer(candidates, seen, raw);
+  }
+
+  if (parentheticals.length === 0 && topLevelAlternates.length === 0) {
+    addAcceptedAnswer(candidates, seen, raw);
+  }
+
+  return candidates;
+}
+
+export function getAcceptedAnswers(answer) {
+  return getAcceptedAnswerCandidates(answer).map((candidate) => candidate.compact);
+}
+
+export function getLevenshteinDistance(a, b) {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const matrix = Array.from({ length: b.length + 1 }, () => []);
+
+  for (let i = 0; i <= b.length; i += 1) matrix[i][0] = i;
+  for (let j = 0; j <= a.length; j += 1) matrix[0][j] = j;
+
+  for (let i = 1; i <= b.length; i += 1) {
+    for (let j = 1; j <= a.length; j += 1) {
+      const cost = b[i - 1] === a[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      );
+
+      if (
+        i > 1
+        && j > 1
+        && b[i - 1] === a[j - 2]
+        && b[i - 2] === a[j - 1]
+      ) {
+        matrix[i][j] = Math.min(matrix[i][j], matrix[i - 2][j - 2] + 1);
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+function isSimplePluralVariation(userAnswer, correctAnswer) {
+  if (userAnswer.length < 4 || correctAnswer.length < 4) return false;
+
+  return (
+    `${userAnswer}s` === correctAnswer
+    || userAnswer === `${correctAnswer}s`
+    || `${userAnswer}es` === correctAnswer
+    || userAnswer === `${correctAnswer}es`
+    || (userAnswer.endsWith('y') && `${userAnswer.slice(0, -1)}ies` === correctAnswer)
+    || (correctAnswer.endsWith('y') && userAnswer === `${correctAnswer.slice(0, -1)}ies`)
+  );
+}
+
+function isWholeAnswerAlias(userAnswer, candidateAnswer) {
+  return Object.entries(WHOLE_ANSWER_ALIASES).some(([canonical, aliases]) => (
+    (candidateAnswer === canonical && aliases.includes(userAnswer))
+    || (userAnswer === canonical && aliases.includes(candidateAnswer))
+  ));
+}
+
+function getFuzzyThreshold(answer) {
+  const length = String(answer || '').length;
+  if (length <= 4) return 0;
+  if (length <= 8) return 1;
+  if (length <= 15) return 2;
+  return 3;
+}
+
+export function compareAnswers(userAnswerRaw, correctAnswerRaw) {
+  return compareAnswersDetailed(userAnswerRaw, correctAnswerRaw).isCorrect;
+}
+
+export function compareAnswersDetailed(userAnswerRaw, correctAnswerRaw) {
+  const userAnswer = cleanAnswer(userAnswerRaw);
+  const acceptedCandidates = getAcceptedAnswerCandidates(correctAnswerRaw);
+  const acceptedAnswers = acceptedCandidates.map((candidate) => candidate.compact);
+  const correctAnswer = acceptedAnswers[0] || '';
+
+  if (!userAnswer || !correctAnswer) {
+    return {
+      isCorrect: false,
+      reason: 'empty',
+      userAnswer,
+      correctAnswer,
+      acceptedAnswers,
+      distance: null,
+      threshold: null,
+    };
+  }
+
+  const exactMatch = acceptedCandidates.find((candidate) => userAnswer === candidate.compact);
+  if (exactMatch) {
+    return {
+      isCorrect: true,
+      reason: 'exact',
+      userAnswer,
+      correctAnswer: exactMatch.compact,
+      acceptedAnswers,
+      distance: 0,
+      threshold: 0,
+    };
+  }
+
+  const variationMatch = acceptedCandidates.find((candidate) => (
+    isWholeAnswerAlias(userAnswer, candidate.compact)
+    || isSimplePluralVariation(userAnswer, candidate.compact)
+  ));
+  if (variationMatch) {
+    return {
+      isCorrect: true,
+      reason: 'variation',
+      userAnswer,
+      correctAnswer: variationMatch.compact,
+      acceptedAnswers,
+      distance: getLevenshteinDistance(userAnswer, variationMatch.compact),
+      threshold: 0,
+    };
+  }
+
+  let bestMatch = {
+    answer: correctAnswer,
+    distance: getLevenshteinDistance(userAnswer, correctAnswer),
+    threshold: getFuzzyThreshold(correctAnswer),
+  };
+
+  acceptedAnswers.slice(1).forEach((acceptedAnswer) => {
+    const distance = getLevenshteinDistance(userAnswer, acceptedAnswer);
+    if (distance < bestMatch.distance) {
+      bestMatch = {
+        answer: acceptedAnswer,
+        distance,
+        threshold: getFuzzyThreshold(acceptedAnswer),
+      };
+    }
+  });
+
+  const isCorrect = bestMatch.distance <= bestMatch.threshold;
+  return {
+    isCorrect,
+    reason: isCorrect ? 'fuzzy' : 'mismatch',
+    userAnswer,
+    correctAnswer: bestMatch.answer,
+    acceptedAnswers,
+    distance: bestMatch.distance,
+    threshold: bestMatch.threshold,
+  };
+}

--- a/src/modes/head-to-head/core/answerMatcher.js
+++ b/src/modes/head-to-head/core/answerMatcher.js
@@ -1,40 +1,21 @@
-function normalizeAnswer(value = '') {
-  return String(value)
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9\s]/g, '')
-    .replace(/\s+/g, ' ');
-}
+import {
+  cleanAnswer,
+  compareAnswers,
+  getLevenshteinDistance,
+} from '../../../core/answerJudge.js';
 
+// Retained as an informational helper for diagnostics/tests. Correctness itself
+// is owned by the shared answer judge below, not a mode-specific threshold.
 export function calculateSimilarity(left = '', right = '') {
-  const a = normalizeAnswer(left);
-  const b = normalizeAnswer(right);
+  const a = cleanAnswer(left);
+  const b = cleanAnswer(right);
   if (a === b) return 1;
   if (!a.length || !b.length) return 0;
 
-  const matrix = Array.from({ length: b.length + 1 }, (_, row) => [row]);
-  for (let column = 0; column <= a.length; column += 1) {
-    matrix[0][column] = column;
-  }
-
-  for (let row = 1; row <= b.length; row += 1) {
-    for (let column = 1; column <= a.length; column += 1) {
-      const cost = b[row - 1] === a[column - 1] ? 0 : 1;
-      matrix[row][column] = Math.min(
-        matrix[row - 1][column - 1] + cost,
-        matrix[row][column - 1] + 1,
-        matrix[row - 1][column] + 1,
-      );
-    }
-  }
-
-  const distance = matrix[b.length][a.length];
+  const distance = getLevenshteinDistance(a, b);
   return 1 - (distance / Math.max(a.length, b.length));
 }
 
-export function isAnswerAccepted(userAnswer, correctAnswer, threshold = 0.8) {
-  if (!String(userAnswer || '').trim() || !String(correctAnswer || '').trim()) {
-    return false;
-  }
-  return calculateSimilarity(userAnswer, correctAnswer) >= threshold;
+export function isAnswerAccepted(userAnswer, correctAnswer) {
+  return compareAnswers(userAnswer, correctAnswer);
 }

--- a/tests/core/answerJudge.test.js
+++ b/tests/core/answerJudge.test.js
@@ -1,0 +1,81 @@
+import {
+  cleanAnswer,
+  compareAnswers,
+  compareAnswersDetailed,
+  getAcceptedAnswers,
+} from '../../src/core/answerJudge.js';
+
+describe('canonical answer judge', () => {
+  test('normalizes Jeopardy phrasing, punctuation, ampersands, and diacritics', () => {
+    expect(cleanAnswer('What is The Eiffel Tower?')).toBe('eiffeltower');
+    expect(cleanAnswer('Who was an Apple?')).toBe('apple');
+    expect(cleanAnswer('What is Crate & Barrel?!')).toBe('crateandbarrel');
+    expect(cleanAnswer('John C. Frémont')).toBe('johncfremont');
+  });
+
+  test('accepts exact answers after normalization', () => {
+    expect(compareAnswers('What is Abraham Lincoln?', 'Abraham Lincoln')).toBe(true);
+    expect(compareAnswers('crate and barrel', 'Crate & Barrel')).toBe(true);
+    expect(compareAnswers('John C Fremont', 'John C. Frémont')).toBe(true);
+  });
+
+  test('accepts safe typos and adjacent transpositions', () => {
+    expect(compareAnswers('washngton', 'Washington')).toBe(true);
+    expect(compareAnswers('recieve', 'receive')).toBe(true);
+
+    const result = compareAnswersDetailed('washngton', 'Washington');
+    expect(result).toMatchObject({
+      isCorrect: true,
+      reason: 'fuzzy',
+      distance: 1,
+    });
+  });
+
+  test('accepts archive-style alternate answers and annotations', () => {
+    expect(compareAnswers('The Eiffel Tower', 'The Eiffel Tower (or La Tour Eiffel)')).toBe(true);
+    expect(compareAnswers('La Tour Eiffel', 'The Eiffel Tower (or La Tour Eiffel)')).toBe(true);
+    expect(compareAnswers('Sri Lanka', 'Ceylon (or Sri Lanka)')).toBe(true);
+    expect(compareAnswers('England', 'Great Britain/England')).toBe(true);
+    expect(compareAnswers('Uranus', 'Neptune (Uranus also accepted)')).toBe(true);
+  });
+
+  test('treats ordinary parentheticals as optional detail, not a standalone answer', () => {
+    expect(getAcceptedAnswers('(Lou) Gehrig')).toEqual(['gehrig', 'lougehrig']);
+    expect(compareAnswers('Gehrig', '(Lou) Gehrig')).toBe(true);
+    expect(compareAnswers('Lou Gehrig', '(Lou) Gehrig')).toBe(true);
+    expect(compareAnswers('Lou', '(Lou) Gehrig')).toBe(false);
+    expect(compareAnswers('Lewis', 'Lewis & Clark')).toBe(false);
+  });
+
+  test('accepts narrow whole-answer aliases and simple plurals', () => {
+    expect(compareAnswers('cities', 'city')).toBe(true);
+    expect(compareAnswers('U.S.A.', 'United States')).toBe(true);
+
+    expect(compareAnswersDetailed('U.S.A.', 'United States')).toMatchObject({
+      isCorrect: true,
+      reason: 'variation',
+    });
+  });
+
+  test('rejects dangerous tiny and near-miss guesses', () => {
+    expect(compareAnswers('cop', 'Copernicus')).toBe(false);
+    expect(compareAnswers('a', 'Australia')).toBe(false);
+    expect(compareAnswers('Iran', 'Iraq')).toBe(false);
+    expect(compareAnswers('Holland', 'Poland')).toBe(false);
+
+    expect(compareAnswersDetailed('Iran', 'Iraq')).toMatchObject({
+      isCorrect: false,
+      reason: 'mismatch',
+      threshold: 0,
+    });
+  });
+
+  test('rejects blank answers', () => {
+    expect(compareAnswers('', 'Saturn')).toBe(false);
+    expect(compareAnswers('Saturn', '')).toBe(false);
+    expect(compareAnswersDetailed('', 'Saturn')).toMatchObject({
+      isCorrect: false,
+      reason: 'empty',
+    });
+  });
+});

--- a/tests/multiplayer/answerMatcher.test.js
+++ b/tests/multiplayer/answerMatcher.test.js
@@ -4,17 +4,18 @@ import {
 } from '../../src/modes/head-to-head/core/answerMatcher.js';
 
 describe('head-to-head answer matcher', () => {
-  test('normalizes case and punctuation', () => {
-    expect(isAnswerAccepted('What is Saturn?', 'Saturn')).toBe(false);
+  test('uses canonical Jeopardy-style normalization', () => {
+    expect(isAnswerAccepted('What is Saturn?', 'Saturn')).toBe(true);
     expect(isAnswerAccepted('SATURN!', 'Saturn')).toBe(true);
   });
 
-  test('accepts close spelling at the existing 0.8 threshold', () => {
+  test('accepts safe spelling variation while retaining similarity diagnostics', () => {
     expect(calculateSimilarity('Shakespear', 'Shakespeare')).toBeGreaterThanOrEqual(0.8);
     expect(isAnswerAccepted('Shakespear', 'Shakespeare')).toBe(true);
   });
 
-  test('rejects blank answers', () => {
+  test('rejects dangerous near misses and blanks', () => {
+    expect(isAnswerAccepted('Iran', 'Iraq')).toBe(false);
     expect(isAnswerAccepted('', 'Saturn')).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Convergence audit #60 found three competing answer-judgment paths in current jeoPARODY. Correctness is domain truth; Main Game and Head-to-Head must not be able to disagree about whether the same response is correct.

## This slice

- adds one deterministic `src/core/answerJudge.js` kernel adapted from behavior already proven in `AlexBaldman/Jeopardish`;
- adds parity fixtures for Jeopardy phrasing, accents, archive alternates, parentheticals, narrow aliases, plurals, transpositions, safe typos, dangerous near-misses, and blanks;
- routes Main Game `GameEngine.checkAnswer()` through the kernel;
- routes Head-to-Head answer adjudication through the same kernel while retaining similarity only as a diagnostic helper;
- captures the bounded Convergence 2.0 capability matrix so cleanup does not erase forgotten proven plans;
- intentionally leaves scoring unchanged for the next explicit convergence slice.

## Product behavior change

This deliberately improves correctness semantics. Examples:

- `What is Saturn?` vs `Saturn` → accepted;
- `John C Fremont` vs `John C. Frémont` → accepted;
- archive alternates such as `The Eiffel Tower (or La Tour Eiffel)` → either accepted;
- `Iran` vs `Iraq`, `Holland` vs `Poland`, `cop` vs `Copernicus` → rejected.

## Guardrail

This is behavioral forward-porting, **not** a wholesale merge of the donor repository. Scoring, episodes, Study, host systems, localization and other recovered capabilities are dispositioned separately in the convergence matrix.

Closes the answer-judgment portion of #60 only. Firebase #44 resumes after the bounded convergence campaign finishes.