### PR TITLE
Refactor: converge Main Game scoring and slim GameEngine

### DIFF
--- a/DEV_JOURNAL.d/2026-08-25T0344-scoring-engine-simplification.md
+++ b/DEV_JOURNAL.d/2026-08-25T0344-scoring-engine-simplification.md
@@ -1,0 +1,9 @@
+# 2026-08-25 03:44 ET — ChatGPT — scoring convergence + GameEngine simplification
+
+- **Read/inspected:** approved Jeopardish `GameEngine` and `ScoreRules` fixtures, current production `GameEngine`, dead/tested `core/scoring.js`, `main.js` orchestration, store persistence, current migration strategy.
+- **Changed:** replaced the unreachable bonus/penalty scoring stack with one pure clue-value score transition; rewired Main Game to authored clue values and approved reset-to-zero incorrect behavior; replaced the 60 FPS trivia timer loop with one question timeout; removed duplicate in-engine content fetching and shadow-store persistence; made achievement state serializable; added deterministic GameEngine timing/scoring/boundary tests.
+- **Evidence/tests:** branch `refactor/canonical-scoring`; full PR CI/browser/security proof required before merge.
+- **Decisions:** Main Game scoring parity is now deliberately simple: correct adds clue value, incorrect/timeout resets current score to zero, no hidden time/difficulty/streak point multipliers. Streak remains a separate state fact. H2H keeps its own mode scoring authority. Content fetching belongs to `main.js`/question services, not domain truth.
+- **Unresolved:** remove transitional dev performance compatibility once `main.js` stops polling the engine; rerun reachability and retire old controller/validator/constants families only if no real consumers remain; continue capability reconciliation under #60.
+- **Next lead domino:** exact-head CI, then dead duplicate authority cleanup + one more GameEngine boundary pass if evidence warrants it.
+- **Refs:** `refactor/canonical-scoring`, issue #60, donor `Jeopardish/tests/engine.test.mjs`.

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -1,607 +1,352 @@
-/**
- * GameEngine - Core Game Logic
- * 
- * Carmack's approach: "The game is a state machine. Everything else is presentation."
- * 
- * This engine manages:
- * - Game flow and state transitions
- * - Question lifecycle 
- * - Scoring and streak calculation
- * - Achievement tracking
- * - Performance monitoring
- * 
- * Zero dependencies on DOM or external services.
- * Pure functions that transform data.
- * 
- * @module core/GameEngine
- */
-
 import { eventBus } from '../utils/events.js';
-import { ACTION_TYPES } from '../state/actions.js';
-import { getQuestion } from '../services/api/questionService.js';
-import { store } from '../state/store.js';
 import { compareAnswers } from './answerJudge.js';
+import { calculateScoreTransition } from './scoring.js';
 
-// Game constants
-export const GAME_CONFIG = {
-  // Scoring
-  BASE_POINTS: 100,
-  STREAK_MULTIPLIER: 0.1,
-  TIME_BONUS_MAX: 50,
-  TIME_LIMIT: 30000, // 30 seconds
-  
-  // Difficulty scaling
-  DIFFICULTY_MULTIPLIERS: {
-    easy: 0.8,
-    normal: 1.0,
-    hard: 1.2,
-    expert: 1.5
-  },
-  
-  // Achievement thresholds
-  ACHIEVEMENTS: {
+export const GAME_CONFIG = Object.freeze({
+  TIME_LIMIT: 30000,
+  ACHIEVEMENTS: Object.freeze({
     FIRST_CORRECT: { id: 'first-correct', threshold: 1 },
     STREAK_MASTER: { id: 'streak-master', threshold: 10 },
     SPEED_DEMON: { id: 'speed-demon', maxTime: 5000 },
     SCHOLAR: { id: 'scholar', threshold: 100 },
-    PERFECTIONIST: { id: 'perfectionist', accuracy: 0.95 }
-  }
-};
+    PERFECTIONIST: { id: 'perfectionist', accuracy: 0.95 },
+  }),
+});
 
-// Game phases
-export const GAME_PHASES = {
+export const GAME_PHASES = Object.freeze({
   MENU: 'menu',
   LOADING: 'loading',
   QUESTION: 'question',
   ANSWERING: 'answering',
   RESULT: 'result',
   COMPLETE: 'complete',
-  PAUSED: 'paused'
-};
+  PAUSED: 'paused',
+});
 
-/**
- * Core game state structure
- */
 export const createGameState = () => ({
-  // Current game session
   session: {
     id: null,
     startTime: 0,
     phase: GAME_PHASES.MENU,
     difficulty: 'normal',
     mode: 'classic',
-    isPaused: false
+    isPaused: false,
   },
-  
-  // Current question
   question: {
     data: null,
     startTime: 0,
     userAnswer: '',
     showingAnswer: false,
-    timeElapsed: 0
+    timeElapsed: 0,
   },
-  
-  // Score tracking
   score: {
     current: 0,
     previous: 0,
     high: 0,
     streak: 0,
     maxStreak: 0,
-    history: []
+    history: [],
   },
-  
-  // Statistics
   stats: {
     questionsAnswered: 0,
     correctAnswers: 0,
     totalTime: 0,
     averageTime: 0,
     accuracy: 0,
-    achievements: new Set()
+    achievements: [],
   },
-  
-  // Performance tracking
-  performance: {
-    frameCount: 0,
-    lastFrameTime: 0,
-    averageFPS: 60
-  }
 });
 
 /**
- * Game Engine Class
- * Manages game state and logic with pure functions
+ * Main Game domain owner.
+ *
+ * The engine owns trivia state transitions, correctness, score/streak state,
+ * timing semantics, statistics, and achievement facts. It deliberately does
+ * not fetch content, render UI, persist a shadow state tree, or run a frame
+ * loop merely to count down a trivia question.
  */
 export class GameEngine {
-  constructor(initialState = createGameState()) {
+  constructor(initialState = createGameState(), {
+    bus = eventBus,
+    now = () => performance.now(),
+    scheduleTimeout = (handler, delay) => setTimeout(handler, delay),
+    cancelTimeout = (id) => clearTimeout(id),
+  } = {}) {
     this.state = initialState;
-    this.eventBus = eventBus;
-    
-    // Performance monitoring
-    this.frameId = null;
-    this.lastUpdate = performance.now();
-    
-    // Game loop
+    this.eventBus = bus;
+    this.now = now;
+    this.scheduleTimeout = scheduleTimeout;
+    this.cancelTimeout = cancelTimeout;
+    this.questionTimeoutId = null;
     this.isRunning = false;
-    
-    // Event handlers
+
     this.setupEventHandlers();
   }
-  
-  /**
-   * Start the game engine
-   */
+
   start() {
     if (this.isRunning) return;
-    
     this.isRunning = true;
-    this.lastUpdate = performance.now();
-    this.gameLoop();
-    
     this.eventBus.emit('game:engine-started');
-    console.log('[🎮] GameEngine started');
   }
-  
-  /**
-   * Stop the game engine
-   */
+
   stop() {
-    this.isRunning = false;
-    if (this.frameId) {
-      cancelAnimationFrame(this.frameId);
-      this.frameId = null;
-    }
-    
-    this.eventBus.emit('game:engine-stopped');
-    console.log('[🎮] GameEngine stopped');
-  }
-  
-  /**
-   * Main game loop - runs at 60fps
-   */
-  gameLoop = () => {
     if (!this.isRunning) return;
-    
-    const now = performance.now();
-    const deltaTime = now - this.lastUpdate;
-    
-    // Update game state
-    this.update(deltaTime);
-    
-    // Performance tracking
-    this.updatePerformanceStats(deltaTime);
-    
-    this.lastUpdate = now;
-    this.frameId = requestAnimationFrame(this.gameLoop);
+    this.isRunning = false;
+    this.clearQuestionTimeout();
+    this.eventBus.emit('game:engine-stopped');
   }
-  
-  /**
-   * Update game state based on current phase
-   * @param {number} deltaTime - Time since last update
-   */
-  update(deltaTime) {
-    switch (this.state.session.phase) {
-      case GAME_PHASES.QUESTION:
-        this.updateQuestionTimer(deltaTime);
-        break;
-      case GAME_PHASES.ANSWERING:
-        this.updateAnsweringPhase(deltaTime);
-        break;
-      case GAME_PHASES.RESULT:
-        this.updateResultPhase(deltaTime);
-        break;
-    }
-  }
-  
-  /**
-   * Update question timer
-   */
-  updateQuestionTimer(deltaTime) {
-    if (!this.state.question.data) return;
-    
-    this.state.question.timeElapsed += deltaTime;
-    
-    // Check for time limit
-    if (this.state.question.timeElapsed >= GAME_CONFIG.TIME_LIMIT) {
-      this.handleTimeUp();
-    }
-  }
-  
-  /**
-   * Handle time limit reached
-   */
-  handleTimeUp() {
-    this.evaluateAnswer('', true); // Empty answer, timed out
-    this.eventBus.emit('game:time-up');
-  }
-  
-  /**
-   * Transition between game phases
-   * @param {string} newPhase - Target phase
-   */
+
   transitionPhase(newPhase) {
     const oldPhase = this.state.session.phase;
     if (oldPhase === newPhase) return;
+
     this.state.session.phase = newPhase;
-    
     this.eventBus.emit('game:phase-changed', {
       from: oldPhase,
       to: newPhase,
-      timestamp: performance.now()
+      timestamp: this.now(),
     });
   }
-  
-  /**
-   * Start a new game session
-   * @param {Object} options - Game options
-   */
+
   startGame(options = {}) {
+    this.clearQuestionTimeout();
     this.state.session = {
       id: `game_${Date.now()}`,
-      startTime: performance.now(),
+      startTime: this.now(),
       phase: GAME_PHASES.LOADING,
       difficulty: options.difficulty || 'normal',
       mode: options.mode || 'classic',
-      isPaused: false
+      isPaused: false,
     };
-    
+
     this.state.score = {
       current: 0,
       previous: this.state.score.current,
       high: Math.max(this.state.score.high, this.state.score.current),
       streak: 0,
       maxStreak: this.state.score.maxStreak,
-      history: []
+      history: [],
     };
-    
+
     this.eventBus.emit('game:started', {
       sessionId: this.state.session.id,
-      options
+      options,
     });
   }
-  
-  /**
-   * Load a new question
-   * @param {Object} questionData - Question data
-   */
+
   loadQuestion(questionData) {
+    this.clearQuestionTimeout();
     this.state.question = {
       data: questionData,
-      startTime: performance.now(),
+      startTime: this.now(),
       userAnswer: '',
       showingAnswer: false,
-      timeElapsed: 0
+      timeElapsed: 0,
     };
-    
+
     this.transitionPhase(GAME_PHASES.QUESTION);
-    
+    this.questionTimeoutId = this.scheduleTimeout(
+      () => this.handleTimeUp(),
+      GAME_CONFIG.TIME_LIMIT,
+    );
+
     this.eventBus.emit('question:loaded', {
       question: questionData,
-      difficulty: this.state.session.difficulty
+      difficulty: this.state.session.difficulty,
     });
   }
-  
-  /**
-   * Submit an answer
-   * @param {string} userAnswer - User's answer
-   */
+
   submitAnswer(userAnswer) {
     if (this.state.session.phase !== GAME_PHASES.QUESTION) {
       console.warn('[GameEngine] Cannot submit answer in phase:', this.state.session.phase);
-      return;
+      return null;
     }
-    
+
+    this.clearQuestionTimeout();
     this.state.question.userAnswer = userAnswer;
+    this.state.question.timeElapsed = Math.max(0, this.now() - this.state.question.startTime);
     this.transitionPhase(GAME_PHASES.ANSWERING);
-    
-    // Evaluate answer
-    this.evaluateAnswer(userAnswer);
+    return this.evaluateAnswer(userAnswer);
   }
-  
-  /**
-   * Evaluate user's answer
-   * @param {string} userAnswer - User's answer
-   * @param {boolean} timedOut - Whether answer timed out
-   */
+
+  handleTimeUp() {
+    if (this.state.session.phase !== GAME_PHASES.QUESTION) return null;
+
+    this.clearQuestionTimeout();
+    this.state.question.timeElapsed = GAME_CONFIG.TIME_LIMIT;
+    const result = this.evaluateAnswer('', true);
+    this.eventBus.emit('game:time-up');
+    return result;
+  }
+
   evaluateAnswer(userAnswer, timedOut = false) {
     const question = this.state.question.data;
-    if (!question) return;
-    
-    const isCorrect = this.checkAnswer(userAnswer, question.answer);
+    if (!question) return null;
+
+    const judgedCorrect = this.checkAnswer(userAnswer, question.answer);
+    const scoreData = calculateScoreTransition({
+      isCorrect: judgedCorrect,
+      timedOut,
+      currentScore: this.state.score.current,
+      clueValue: question.value,
+    });
+    const isCorrect = scoreData.isCorrect;
     const timeElapsed = this.state.question.timeElapsed;
-    
-    // Calculate score
-    const scoreData = this.calculateScore(isCorrect, timeElapsed, timedOut);
-    
-    // Update statistics
-    this.updateStatistics(isCorrect, timeElapsed, timedOut);
-    
-    // Update score and streak
-    this.updateScore(scoreData);
-    
-    // Check achievements
+
+    this.updateStatistics(isCorrect, timeElapsed);
+    this.updateScore(scoreData, isCorrect);
     this.checkAchievements();
-    
     this.transitionPhase(GAME_PHASES.RESULT);
-    
-    this.eventBus.emit('answer:evaluated', {
+
+    const result = {
       userAnswer,
       correctAnswer: question.answer,
       isCorrect,
       timedOut,
       score: scoreData,
-      timeElapsed
-    });
+      timeElapsed,
+    };
+
+    this.eventBus.emit('answer:evaluated', result);
+    return result;
   }
-  
-  /**
-   * Check correctness through the canonical deterministic answer judge.
-   * @param {string} userAnswer - User's answer
-   * @param {string} correctAnswer - Correct answer
-   * @returns {boolean} Whether answer is correct
-   */
+
   checkAnswer(userAnswer, correctAnswer) {
     return compareAnswers(userAnswer, correctAnswer);
   }
-  
-  /**
-   * Calculate score based on correctness and time
-   * @param {boolean} isCorrect - Whether answer was correct
-   * @param {number} timeElapsed - Time taken to answer
-   * @param {boolean} timedOut - Whether answer timed out
-   * @returns {Object} Score data
-   */
-  calculateScore(isCorrect, timeElapsed, timedOut) {
-    if (!isCorrect || timedOut) {
-      return {
-        base: 0,
-        timeBonus: 0,
-        streakBonus: 0,
-        total: 0
-      };
-    }
-    
-    const difficulty = GAME_CONFIG.DIFFICULTY_MULTIPLIERS[this.state.session.difficulty];
-    const basePoints = GAME_CONFIG.BASE_POINTS * difficulty;
-    
-    // Time bonus (faster = more points)
-    const timeRatio = Math.max(0, 1 - (timeElapsed / GAME_CONFIG.TIME_LIMIT));
-    const timeBonus = Math.floor(GAME_CONFIG.TIME_BONUS_MAX * timeRatio);
-    
-    // Streak bonus
-    const streakBonus = Math.floor(basePoints * this.state.score.streak * GAME_CONFIG.STREAK_MULTIPLIER);
-    
-    const total = basePoints + timeBonus + streakBonus;
-    
-    return {
-      base: basePoints,
-      timeBonus,
-      streakBonus,
-      total: Math.floor(total)
-    };
-  }
-  
-  /**
-   * Update score and streak
-   * @param {Object} scoreData - Score calculation result
-   */
-  updateScore(scoreData) {
-    const wasCorrect = scoreData.total > 0;
-    
-    // Update score
-    this.state.score.current += scoreData.total;
-    this.state.score.high = Math.max(this.state.score.high, this.state.score.current);
-    
-    // Update streak
+
+  updateScore(scoreData, wasCorrect) {
+    this.state.score.previous = scoreData.previousScore;
+    this.state.score.current = scoreData.newScore;
+    this.state.score.high = Math.max(this.state.score.high, scoreData.newScore);
+
     if (wasCorrect) {
-      this.state.score.streak++;
-      this.state.score.maxStreak = Math.max(this.state.score.maxStreak, this.state.score.streak);
+      this.state.score.streak += 1;
+      this.state.score.maxStreak = Math.max(
+        this.state.score.maxStreak,
+        this.state.score.streak,
+      );
     } else {
       this.state.score.streak = 0;
     }
-    
-    // Add to history
+
     this.state.score.history.push({
       question: this.state.question.data,
-      score: scoreData.total,
+      clueValue: scoreData.clueValue,
+      scoreDelta: scoreData.scoreDelta,
+      score: scoreData.newScore,
       correct: wasCorrect,
-      timestamp: performance.now()
+      timestamp: this.now(),
     });
-    
-    // Keep history manageable
+
     if (this.state.score.history.length > 100) {
       this.state.score.history = this.state.score.history.slice(-100);
     }
 
-    // Dispatch state update to the central store for persistence
-    store.dispatch('UPDATE', {
-      score: this.state.score,
-      statistics: this.state.stats
+    this.eventBus.emit('game:score-changed', {
+      ...scoreData,
+      streak: this.state.score.streak,
+      maxStreak: this.state.score.maxStreak,
     });
   }
-  
-  /**
-   * Update game statistics
-   * @param {boolean} isCorrect - Whether answer was correct
-   * @param {number} timeElapsed - Time taken to answer
-   * @param {boolean} timedOut - Whether answer timed out
-   */
-  updateStatistics(isCorrect, timeElapsed, timedOut) {
-    this.state.stats.questionsAnswered++;
-    
-    if (isCorrect && !timedOut) {
-      this.state.stats.correctAnswers++;
-    }
-    
+
+  updateStatistics(isCorrect, timeElapsed) {
+    this.state.stats.questionsAnswered += 1;
+    if (isCorrect) this.state.stats.correctAnswers += 1;
+
     this.state.stats.totalTime += timeElapsed;
     this.state.stats.averageTime = this.state.stats.totalTime / this.state.stats.questionsAnswered;
     this.state.stats.accuracy = this.state.stats.correctAnswers / this.state.stats.questionsAnswered;
   }
-  
-  /**
-   * Check and unlock achievements
-   */
+
   checkAchievements() {
     const achievements = GAME_CONFIG.ACHIEVEMENTS;
     const stats = this.state.stats;
     const score = this.state.score;
-    
-    // First correct answer
-    if (stats.correctAnswers >= 1 && !stats.achievements.has(achievements.FIRST_CORRECT.id)) {
+
+    if (stats.correctAnswers >= 1) {
       this.unlockAchievement(achievements.FIRST_CORRECT.id);
     }
-    
-    // Streak master
-    if (score.streak >= achievements.STREAK_MASTER.threshold && !stats.achievements.has(achievements.STREAK_MASTER.id)) {
+    if (score.streak >= achievements.STREAK_MASTER.threshold) {
       this.unlockAchievement(achievements.STREAK_MASTER.id);
     }
-    
-    // Speed demon (last answer was fast)
-    if (this.state.question.timeElapsed <= achievements.SPEED_DEMON.maxTime
-     && this.state.score.history.at(-1)?.correct
-     && !stats.achievements.has(achievements.SPEED_DEMON.id)) {
+    if (
+      this.state.question.timeElapsed <= achievements.SPEED_DEMON.maxTime
+      && score.history.at(-1)?.correct
+    ) {
       this.unlockAchievement(achievements.SPEED_DEMON.id);
     }
-    
-    // Scholar (total questions)
-    if (stats.questionsAnswered >= achievements.SCHOLAR.threshold && !stats.achievements.has(achievements.SCHOLAR.id)) {
+    if (stats.questionsAnswered >= achievements.SCHOLAR.threshold) {
       this.unlockAchievement(achievements.SCHOLAR.id);
     }
-    
-    // Perfectionist (high accuracy with sufficient questions)
-    if (stats.questionsAnswered >= 20 && stats.accuracy >= achievements.PERFECTIONIST.accuracy && !stats.achievements.has(achievements.PERFECTIONIST.id)) {
+    if (
+      stats.questionsAnswered >= 20
+      && stats.accuracy >= achievements.PERFECTIONIST.accuracy
+    ) {
       this.unlockAchievement(achievements.PERFECTIONIST.id);
     }
   }
-  
-  /**
-   * Unlock an achievement
-   * @param {string} achievementId - Achievement ID
-   */
+
   unlockAchievement(achievementId) {
-    this.state.stats.achievements.add(achievementId);
-    
+    if (this.state.stats.achievements.includes(achievementId)) return;
+
+    this.state.stats.achievements.push(achievementId);
     this.eventBus.emit('achievement:unlocked', {
       achievementId,
-      timestamp: performance.now()
+      timestamp: this.now(),
     });
   }
-  
-  /**
-   * Update performance statistics
-   * @param {number} deltaTime - Time since last frame
-   */
-  updatePerformanceStats(deltaTime) {
-    this.state.performance.frameCount++;
-    this._accumulatedDelta = (this._accumulatedDelta || 0) + deltaTime;
 
-    // Calculate FPS every 60 frames
-    if (this.state.performance.frameCount % 60 === 0) {
-      const avgDelta = this._accumulatedDelta / 60;
-      const fps = 1000 / avgDelta;
-      this.state.performance.averageFPS = (this.state.performance.averageFPS + fps) / 2;
-      this._accumulatedDelta = 0;
-      
-      // Warn if performance is poor
-      if (this.state.performance.averageFPS < 30) {
-        console.warn('[GameEngine] Low FPS detected:', this.state.performance.averageFPS);
-      }
-    }
+  clearQuestionTimeout() {
+    if (this.questionTimeoutId == null) return;
+    this.cancelTimeout(this.questionTimeoutId);
+    this.questionTimeoutId = null;
   }
-  
-  /**
-   * Get current game state (immutable)
-   * @returns {Object} Game state
-   */
+
   getState() {
-    return JSON.parse(JSON.stringify(this.state));
-  }
-  
-  /**
-   * Get performance stats
-   * @returns {Object} Performance data
-   */
-  getPerformanceStats() {
-    return {
-      ...this.state.performance,
-      memoryUsage: performance.memory ? {
-        used: Math.round(performance.memory.usedJSHeapSize / 1024 / 1024),
-        total: Math.round(performance.memory.totalJSHeapSize / 1024 / 1024),
-        limit: Math.round(performance.memory.jsHeapSizeLimit / 1024 / 1024)
-      } : null
-    };
-  }
-  
-  /**
-   * Setup event handlers
-   */
-  /**
-   * Request a new question from the question service
-   */
-  async handleNewQuestionRequest() {
-    console.log('[GameEngine] Requesting new question...');
-    const question = await getQuestion();
-    if (question) {
-      this.eventBus.emit('question:load', { question });
-    } else {
-      console.error('[GameEngine] Failed to get a new question from the service.');
-      this.eventBus.emit('game:error', { message: 'Could not load a new question.' });
-    }
+    return structuredClone(this.state);
   }
 
   setupEventHandlers() {
-    // Game control events
     this.eventBus.on('game:start', (options) => this.startGame(options));
     this.eventBus.on('game:pause', () => this.pauseGame());
     this.eventBus.on('game:resume', () => this.resumeGame());
     this.eventBus.on('game:reset', () => this.resetGame());
-    
-    // Question events
-    this.eventBus.on('question:request-new', () => this.handleNewQuestionRequest());
     this.eventBus.on('question:load', (data) => this.loadQuestion(data.question));
     this.eventBus.on('answer:submit', (data) => this.submitAnswer(data.answer));
   }
-  
-  /**
-   * Pause the game
-   */
+
   pauseGame() {
+    if (this.state.session.phase !== GAME_PHASES.QUESTION) return;
+
+    this.clearQuestionTimeout();
     this.state.session.isPaused = true;
     this.transitionPhase(GAME_PHASES.PAUSED);
     this.eventBus.emit('game:paused');
   }
-  
-  /**
-   * Resume the game
-   */
+
   resumeGame() {
+    if (!this.state.session.isPaused) return;
+
     this.state.session.isPaused = false;
     this.transitionPhase(GAME_PHASES.QUESTION);
+    const remaining = Math.max(0, GAME_CONFIG.TIME_LIMIT - this.state.question.timeElapsed);
+    this.questionTimeoutId = this.scheduleTimeout(() => this.handleTimeUp(), remaining);
     this.eventBus.emit('game:resumed');
   }
-  
-  /**
-   * Reset the game
-   */
+
   resetGame() {
+    this.clearQuestionTimeout();
     this.state = createGameState();
-    this.transitionPhase(GAME_PHASES.MENU);
     this.eventBus.emit('game:reset');
   }
 }
 
-// Export singleton instance
 let gameEngineInstance = null;
 
 export function getGameEngine() {
   if (!gameEngineInstance) {
-    // The GameEngine maintains its own internal state shape.
-    // Do not pass the app store state directly, as structures differ.
-    const initialState = createGameState();
-    console.log('[GameEngine] Initializing with engine state:', initialState);
-    gameEngineInstance = new GameEngine(initialState);
+    gameEngineInstance = new GameEngine(createGameState());
   }
   return gameEngineInstance;
 }

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -304,7 +304,7 @@ export class GameEngine {
   }
 
   getState() {
-    return structuredClone(this.state);
+    return JSON.parse(JSON.stringify(this.state));
   }
 
   // Transitional compatibility for the dev HUD. Performance sampling no longer

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -307,6 +307,15 @@ export class GameEngine {
     return structuredClone(this.state);
   }
 
+  // Transitional compatibility for the dev HUD. Performance sampling no longer
+  // lives inside domain state or drives a 60 FPS loop.
+  getPerformanceStats() {
+    return {
+      running: this.isRunning,
+      questionTimerActive: this.questionTimeoutId != null,
+    };
+  }
+
   setupEventHandlers() {
     this.eventBus.on('game:start', (options) => this.startGame(options));
     this.eventBus.on('game:pause', () => this.pauseGame());
@@ -319,6 +328,7 @@ export class GameEngine {
   pauseGame() {
     if (this.state.session.phase !== GAME_PHASES.QUESTION) return;
 
+    this.state.question.timeElapsed = Math.max(0, this.now() - this.state.question.startTime);
     this.clearQuestionTimeout();
     this.state.session.isPaused = true;
     this.transitionPhase(GAME_PHASES.PAUSED);
@@ -329,6 +339,7 @@ export class GameEngine {
     if (!this.state.session.isPaused) return;
 
     this.state.session.isPaused = false;
+    this.state.question.startTime = this.now() - this.state.question.timeElapsed;
     this.transitionPhase(GAME_PHASES.QUESTION);
     const remaining = Math.max(0, GAME_CONFIG.TIME_LIMIT - this.state.question.timeElapsed);
     this.questionTimeoutId = this.scheduleTimeout(() => this.handleTimeUp(), remaining);

--- a/src/core/scoring.js
+++ b/src/core/scoring.js
@@ -1,357 +1,63 @@
 /**
- * Scoring System Module
- * 
- * Carmack's principle: "Make the math obvious. 
- * Complex scoring systems often hide bugs."
+ * Canonical Main Game scoring truth.
+ *
+ * Carmack filter: make the rule obvious enough to inspect without a diagram.
+ * Correct answers add the authored clue value. Incorrect/timed-out answers reset
+ * the current score to zero, matching the approved Jeopardish parity behavior.
+ * Presentation, achievements, persistence, and multiplayer scoring stay outside
+ * this pure transition.
  */
 
-import { SCORING, RULES } from '../utils/constants.js';
-import { clamp } from '../utils/helpers.js';
-import { emitGameEvent, GAME_EVENTS } from '../utils/events.js';
+export const SCORE_RULES = Object.freeze({
+  incorrectScoreMode: 'reset-to-zero',
+  allowNegativeScore: false,
+  defaultClueValue: 100,
+});
 
-/**
- * Score Calculator
- * Handles all score calculations with clear, predictable rules
- */
-export class ScoreCalculator {
-  /**
-   * Calculate score for a correct answer
-   * @param {Object} params - Scoring parameters
-   * @returns {number} Calculated score
-   */
-  static calculateCorrectScore(params) {
-    const {
-      baseValue = 200,
-      timeElapsed = 0,
-      streak = 0,
-      difficulty = 'medium',
-      peekUsed = false
-    } = params;
+export function parseClueValue(value, fallback = SCORE_RULES.defaultClueValue) {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.round(value);
+  }
 
-    // No points if answer was revealed
-    if (peekUsed) {
-      return 0;
+  if (typeof value === 'string') {
+    const digits = value.replace(/[^0-9]/g, '');
+    const parsed = Number(digits);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
     }
-
-    // Base score
-    let score = baseValue * SCORING.CORRECT_MULTIPLIER;
-
-    // Time bonus
-    const timeBonus = this.calculateTimeBonus(timeElapsed);
-    score += timeBonus;
-
-    // Streak bonus
-    const streakBonus = this.calculateStreakBonus(streak, baseValue);
-    score += streakBonus;
-
-    // Difficulty multiplier
-    const difficultyMultiplier = this.getDifficultyMultiplier(difficulty);
-    score = Math.round(score * difficultyMultiplier);
-
-    return Math.max(0, score);
   }
 
-  /**
-   * Calculate score for an incorrect answer
-   * @param {Object} params - Scoring parameters
-   * @returns {number} Calculated penalty
-   */
-  static calculateIncorrectScore(params) {
-    const {
-      baseValue = 200,
-      peekUsed = false
-    } = params;
-
-    // Different penalty if peek was used
-    if (peekUsed) {
-      return -Math.round(baseValue * SCORING.INCORRECT_PENALTY * 2);
-    }
-
-    return -Math.round(baseValue * SCORING.INCORRECT_PENALTY);
-  }
-
-  /**
-   * Calculate time bonus
-   * @param {number} timeElapsed - Time in milliseconds
-   * @returns {number} Time bonus
-   */
-  static calculateTimeBonus(timeElapsed) {
-    const secondsElapsed = Math.floor(timeElapsed / 1000);
-    const timeBonus = SCORING.TIME_BONUS_MAX - (secondsElapsed * SCORING.TIME_BONUS_DECAY);
-    return Math.max(0, timeBonus);
-  }
-
-  /**
-   * Calculate streak bonus
-   * @param {number} streak - Current streak
-   * @param {number} baseValue - Base question value
-   * @returns {number} Streak bonus
-   */
-  static calculateStreakBonus(streak, baseValue) {
-    let multiplier = 1; // Start with 1 so (multiplier - 1) is 0 if no bonus applies
-
-    // Find the highest applicable streak bonus
-    for (const [threshold, bonus] of Object.entries(SCORING.STREAK_BONUS)) {
-      if (streak >= parseInt(threshold)) {
-        multiplier = bonus;
-      }
-    }
-
-    return Math.round(baseValue * (multiplier - 1));
-  }
-
-  /**
-   * Get difficulty multiplier
-   * @param {string} difficulty - Difficulty level
-   * @returns {number} Multiplier
-   */
-  static getDifficultyMultiplier(difficulty) {
-    const multipliers = {
-      easy: 0.8,
-      medium: 1.0,
-      hard: 1.5,
-      expert: 2.0
-    };
-
-    return multipliers[difficulty] || 1.0;
-  }
-
-  /**
-   * Calculate round score summary
-   * @param {Object} roundData - Round data
-   * @returns {Object} Score breakdown
-   */
-  static calculateRoundScore(roundData) {
-    const {
-      isCorrect,
-      baseValue,
-      timeElapsed,
-      streak,
-      difficulty,
-      peekUsed
-    } = roundData;
-
-    if (!isCorrect) {
-      const penalty = this.calculateIncorrectScore({ baseValue, peekUsed });
-      return {
-        total: penalty,
-        breakdown: {
-          base: 0,
-          timeBonus: 0,
-          streakBonus: 0,
-          difficultyBonus: 0,
-          penalty
-        }
-      };
-    }
-
-    const params = {
-      baseValue,
-      timeElapsed,
-      streak,
-      difficulty,
-      peekUsed
-    };
-
-    const total = this.calculateCorrectScore(params);
-    const timeBonus = peekUsed ? 0 : this.calculateTimeBonus(timeElapsed);
-    const streakBonus = peekUsed ? 0 : this.calculateStreakBonus(streak, baseValue);
-    const difficultyMultiplier = this.getDifficultyMultiplier(difficulty);
-
-    return {
-      total,
-      breakdown: {
-        base: peekUsed ? 0 : baseValue,
-        timeBonus,
-        streakBonus,
-        difficultyBonus: peekUsed ? 0 : Math.round((baseValue * difficultyMultiplier) - baseValue),
-        penalty: 0
-      }
-    };
-  }
+  return fallback;
 }
 
-/**
- * Score Tracker
- * Tracks scores, streaks, and achievements
- */
-export class ScoreTracker {
-  constructor() {
-    this.currentScore = 0;
-    this.highScore = 0;
-    this.currentStreak = 0;
-    this.bestStreak = 0;
-    this.totalCorrect = 0;
-    this.totalQuestions = 0;
-    this.scoreHistory = [];
-    this.achievements = new Set();
+export function calculateScoreTransition({
+  isCorrect,
+  timedOut = false,
+  currentScore = 0,
+  clueValue,
+  rules = SCORE_RULES,
+} = {}) {
+  const previousScore = Number.isFinite(Number(currentScore))
+    ? Math.max(0, Number(currentScore))
+    : 0;
+  const resolvedClueValue = parseClueValue(clueValue, rules.defaultClueValue);
+  const accepted = Boolean(isCorrect) && !timedOut;
+
+  let newScore;
+  if (accepted) {
+    newScore = previousScore + resolvedClueValue;
+  } else if (rules.incorrectScoreMode === 'subtract') {
+    const candidate = previousScore - resolvedClueValue;
+    newScore = rules.allowNegativeScore ? candidate : Math.max(0, candidate);
+  } else {
+    newScore = 0;
   }
 
-  /**
-   * Add score
-   * @param {number} points - Points to add
-   * @param {Object} metadata - Score metadata
-   */
-  addScore(points, metadata = {}) {
-    const previousScore = this.currentScore;
-    this.currentScore = Math.max(0, this.currentScore + points);
-
-    // Track history
-    this.scoreHistory.push({
-      timestamp: Date.now(),
-      points,
-      total: this.currentScore,
-      ...metadata
-    });
-
-    // Check for high score
-    if (this.currentScore > this.highScore) {
-      this.highScore = this.currentScore;
-      emitGameEvent(GAME_EVENTS.HIGH_SCORE_ACHIEVED, {
-        score: this.highScore,
-        previous: previousScore
-      });
-    }
-
-    // Emit score update
-    emitGameEvent(GAME_EVENTS.SCORE_UPDATED, {
-      current: this.currentScore,
-      high: this.highScore,
-      change: points
-    });
-
-    // Check achievements
-    this.checkAchievements();
-  }
-
-  /**
-   * Update streak
-   * @param {boolean} correct - Whether answer was correct
-   */
-  updateStreak(correct) {
-    if (correct) {
-      this.currentStreak++;
-      this.totalCorrect++;
-      
-      if (this.currentStreak > this.bestStreak) {
-        this.bestStreak = this.currentStreak;
-      }
-
-      // Check streak achievements
-      this.checkStreakAchievements();
-    } else {
-      this.currentStreak = 0;
-    }
-
-    this.totalQuestions++;
-
-    emitGameEvent(GAME_EVENTS.STREAK_UPDATED, {
-      current: this.currentStreak,
-      best: this.bestStreak
-    });
-  }
-
-  /**
-   * Get accuracy percentage
-   * @returns {number} Accuracy percentage
-   */
-  getAccuracy() {
-    if (this.totalQuestions === 0) return 0;
-    return Math.round((this.totalCorrect / this.totalQuestions) * 100);
-  }
-
-  /**
-   * Check for achievements
-   */
-  checkAchievements() {
-    const achievements = [
-      { id: 'first_correct', condition: () => this.totalCorrect === 1 },
-      { id: 'score_1000', condition: () => this.currentScore >= 1000 },
-      { id: 'score_5000', condition: () => this.currentScore >= 5000 },
-      { id: 'score_10000', condition: () => this.currentScore >= 10000 },
-      { id: 'perfect_10', condition: () => this.getAccuracy() === 100 && this.totalQuestions >= 10 }
-    ];
-
-    for (const achievement of achievements) {
-      if (!this.achievements.has(achievement.id) && achievement.condition()) {
-        this.achievements.add(achievement.id);
-        emitGameEvent(GAME_EVENTS.ACHIEVEMENT_UNLOCKED, {
-          id: achievement.id,
-          timestamp: Date.now()
-        });
-      }
-    }
-  }
-
-  /**
-   * Check streak achievements
-   */
-  checkStreakAchievements() {
-    const streakAchievements = [
-      { id: 'streak_3', threshold: 3 },
-      { id: 'streak_5', threshold: 5 },
-      { id: 'streak_10', threshold: 10 },
-      { id: 'streak_20', threshold: 20 }
-    ];
-
-    for (const achievement of streakAchievements) {
-      if (!this.achievements.has(achievement.id) && this.currentStreak >= achievement.threshold) {
-        this.achievements.add(achievement.id);
-        emitGameEvent(GAME_EVENTS.ACHIEVEMENT_UNLOCKED, {
-          id: achievement.id,
-          streak: this.currentStreak
-        });
-      }
-    }
-  }
-
-  /**
-   * Get statistics
-   * @returns {Object} Score statistics
-   */
-  getStats() {
-    return {
-      currentScore: this.currentScore,
-      highScore: this.highScore,
-      currentStreak: this.currentStreak,
-      bestStreak: this.bestStreak,
-      totalCorrect: this.totalCorrect,
-      totalQuestions: this.totalQuestions,
-      accuracy: this.getAccuracy(),
-      achievements: Array.from(this.achievements),
-      averageScore: this.calculateAverageScore()
-    };
-  }
-
-  /**
-   * Calculate average score per question
-   * @returns {number} Average score
-   */
-  calculateAverageScore() {
-    if (this.totalQuestions === 0) return 0;
-    return Math.round(this.currentScore / this.totalQuestions);
-  }
-
-  /**
-   * Reset tracker
-   */
-  reset() {
-    this.currentScore = 0;
-    this.currentStreak = 0;
-    this.totalCorrect = 0;
-    this.totalQuestions = 0;
-    this.scoreHistory = [];
-    // Keep high score and achievements
-  }
-
-  /**
-   * Export score data
-   * @returns {Object} Score data
-   */
-  export() {
-    return {
-      ...this.getStats(),
-      history: this.scoreHistory
-    };
-  }
+  return {
+    isCorrect: accepted,
+    clueValue: resolvedClueValue,
+    previousScore,
+    newScore,
+    scoreDelta: newScore - previousScore,
+  };
 }

--- a/tests/core/GameEngine.test.js
+++ b/tests/core/GameEngine.test.js
@@ -1,0 +1,148 @@
+import {
+  GameEngine,
+  GAME_CONFIG,
+  GAME_PHASES,
+  createGameState,
+} from '@/core/GameEngine.js';
+
+function createBus() {
+  const handlers = new Map();
+  const events = [];
+  return {
+    events,
+    on(type, handler) {
+      const list = handlers.get(type) || [];
+      list.push(handler);
+      handlers.set(type, list);
+    },
+    emit(type, payload) {
+      events.push({ type, payload });
+      for (const handler of handlers.get(type) || []) handler(payload);
+    },
+  };
+}
+
+function createHarness() {
+  const bus = createBus();
+  const timers = new Map();
+  let nextTimerId = 1;
+  let now = 1000;
+
+  const engine = new GameEngine(createGameState(), {
+    bus,
+    now: () => now,
+    scheduleTimeout(handler, delay) {
+      const id = nextTimerId++;
+      timers.set(id, { handler, delay });
+      return id;
+    },
+    cancelTimeout(id) {
+      timers.delete(id);
+    },
+  });
+
+  return {
+    engine,
+    bus,
+    timers,
+    advance(ms) {
+      now += ms;
+    },
+    fireOnlyTimer() {
+      const [[id, timer]] = timers.entries();
+      timers.delete(id);
+      timer.handler();
+    },
+  };
+}
+
+const clue = {
+  id: 'chicago-1893',
+  category: 'History',
+  question: 'This city hosted the 1893 World Columbian Exposition.',
+  answer: 'What is Chicago?',
+  value: '$400',
+};
+
+describe('Main GameEngine domain contract', () => {
+  test('correct answers add authored clue value and use the canonical judge', () => {
+    const h = createHarness();
+    h.engine.startGame();
+    h.engine.loadQuestion(clue);
+    h.advance(2200);
+
+    const result = h.engine.submitAnswer('Chicago');
+
+    expect(result).toMatchObject({
+      isCorrect: true,
+      timedOut: false,
+      score: {
+        clueValue: 400,
+        previousScore: 0,
+        newScore: 400,
+        scoreDelta: 400,
+      },
+    });
+    expect(h.engine.state.score.current).toBe(400);
+    expect(h.engine.state.score.streak).toBe(1);
+    expect(h.engine.state.session.phase).toBe(GAME_PHASES.RESULT);
+    expect(h.timers.size).toBe(0);
+  });
+
+  test('incorrect answers reset score and streak to match approved donor parity', () => {
+    const h = createHarness();
+    h.engine.startGame();
+    h.engine.loadQuestion(clue);
+    h.engine.submitAnswer('Chicago');
+
+    h.engine.loadQuestion({ ...clue, id: 'second', value: '$800' });
+    const result = h.engine.submitAnswer('Boston');
+
+    expect(result).toMatchObject({
+      isCorrect: false,
+      score: {
+        previousScore: 400,
+        newScore: 0,
+        scoreDelta: -400,
+      },
+    });
+    expect(h.engine.state.score.current).toBe(0);
+    expect(h.engine.state.score.streak).toBe(0);
+    expect(h.engine.state.score.high).toBe(400);
+  });
+
+  test('question timeout is event-driven rather than frame-loop driven', () => {
+    const h = createHarness();
+    h.engine.startGame();
+    h.engine.loadQuestion(clue);
+
+    expect(h.timers.size).toBe(1);
+    expect([...h.timers.values()][0].delay).toBe(GAME_CONFIG.TIME_LIMIT);
+
+    h.advance(GAME_CONFIG.TIME_LIMIT);
+    h.fireOnlyTimer();
+
+    expect(h.engine.state.session.phase).toBe(GAME_PHASES.RESULT);
+    expect(h.engine.state.stats.questionsAnswered).toBe(1);
+    expect(h.bus.events.some(({ type }) => type === 'game:time-up')).toBe(true);
+  });
+
+  test('state is serializable and no longer contains Set-based achievement truth', () => {
+    const h = createHarness();
+    h.engine.startGame();
+    h.engine.loadQuestion(clue);
+    h.engine.submitAnswer('Chicago');
+
+    const snapshot = h.engine.getState();
+    expect(Array.isArray(snapshot.stats.achievements)).toBe(true);
+    expect(() => JSON.stringify(snapshot)).not.toThrow();
+  });
+
+  test('content fetching and frame-loop phase methods are not engine responsibilities', () => {
+    const h = createHarness();
+    expect(h.engine.handleNewQuestionRequest).toBeUndefined();
+    expect(h.engine.gameLoop).toBeUndefined();
+    expect(h.engine.updateAnsweringPhase).toBeUndefined();
+    expect(h.engine.updateResultPhase).toBeUndefined();
+  });
+});

--- a/tests/core/scoring.test.js
+++ b/tests/core/scoring.test.js
@@ -1,115 +1,76 @@
-import { ScoreCalculator } from '@/core/scoring.js';
+import {
+  SCORE_RULES,
+  calculateScoreTransition,
+  parseClueValue,
+} from '@/core/scoring.js';
 
-describe('ScoreCalculator', () => {
-  test('calculates correct score with time and streak bonuses', () => {
-    const score = ScoreCalculator.calculateCorrectScore({
-      baseValue: 200,
-      timeElapsed: 3000, // 3s => bonus = 500 - (3*10) = 470
-      streak: 5,         // threshold 5 => multiplier 2 => +200
-      difficulty: 'hard' // x1.5
+describe('canonical Main Game scoring', () => {
+  test('parses authored numeric and display clue values', () => {
+    expect(parseClueValue(400)).toBe(400);
+    expect(parseClueValue('$800')).toBe(800);
+    expect(parseClueValue('1,200')).toBe(1200);
+    expect(parseClueValue('')).toBe(SCORE_RULES.defaultClueValue);
+    expect(parseClueValue(null, 200)).toBe(200);
+  });
+
+  test('correct answers add exactly the authored clue value', () => {
+    expect(calculateScoreTransition({
+      isCorrect: true,
+      currentScore: 600,
+      clueValue: '$400',
+    })).toEqual({
+      isCorrect: true,
+      clueValue: 400,
+      previousScore: 600,
+      newScore: 1000,
+      scoreDelta: 400,
     });
-    // base 200 + time 470 + streak 200 = 870; x1.5 = 1305
-    expect(score).toBe(1305);
   });
 
-  test('returns 0 for peekUsed on correct', () => {
-    const score = ScoreCalculator.calculateCorrectScore({ baseValue: 400, peekUsed: true });
-    expect(score).toBe(0);
-  });
-
-  test('incorrect score applies penalty and peek doubles it', () => {
-    const normal = ScoreCalculator.calculateIncorrectScore({ baseValue: 200 });
-    const peeked = ScoreCalculator.calculateIncorrectScore({ baseValue: 200, peekUsed: true });
-    expect(normal).toBe(-100); // 200 * 0.5
-    expect(peeked).toBe(-200); // doubled
-  });
-
-  test('time bonus never negative', () => {
-    const bonus = ScoreCalculator.calculateTimeBonus(60000); // 60s => would be negative
-    expect(bonus).toBe(0);
-  });
-
-  test('calculates streak bonus correctly', () => {
-    expect(ScoreCalculator.calculateStreakBonus(0, 100)).toBe(0);
-    expect(ScoreCalculator.calculateStreakBonus(2, 100)).toBe(0);
-    expect(ScoreCalculator.calculateStreakBonus(3, 100)).toBe(50); // 100 * (1.5 - 1)
-    expect(ScoreCalculator.calculateStreakBonus(4, 100)).toBe(50); // Still 100 * (1.5 - 1)
-    expect(ScoreCalculator.calculateStreakBonus(5, 100)).toBe(100); // 100 * (2 - 1)
-    expect(ScoreCalculator.calculateStreakBonus(9, 100)).toBe(100); // Still 100 * (2 - 1)
-    expect(ScoreCalculator.calculateStreakBonus(10, 100)).toBe(200); // 100 * (3 - 1)
-  });
-
-  test('gets difficulty multiplier correctly', () => {
-    expect(ScoreCalculator.getDifficultyMultiplier('easy')).toBe(0.8);
-    expect(ScoreCalculator.getDifficultyMultiplier('medium')).toBe(1.0);
-    expect(ScoreCalculator.getDifficultyMultiplier('hard')).toBe(1.5);
-    expect(ScoreCalculator.getDifficultyMultiplier('expert')).toBe(2.0);
-    expect(ScoreCalculator.getDifficultyMultiplier('unknown')).toBe(1.0); // Default to medium
-  });
-
-  describe('calculateRoundScore', () => {
-    test('calculates correct round score with breakdown', () => {
-      const roundData = {
-        isCorrect: true,
-        baseValue: 200,
-        timeElapsed: 3000,
-        streak: 5,
-        difficulty: 'hard',
-        peekUsed: false
-      };
-      const result = ScoreCalculator.calculateRoundScore(roundData);
-      // base 200 + time 470 + streak 200 = 870; x1.5 = 1305
-      expect(result.total).toBe(1305);
-      expect(result.breakdown.base).toBe(200);
-      expect(result.breakdown.timeBonus).toBe(470);
-      expect(result.breakdown.streakBonus).toBe(200);
-      expect(result.breakdown.difficultyBonus).toBe(100); // (200 * 1.5) - 200 = 100
-      expect(result.breakdown.penalty).toBe(0);
+  test('incorrect answers reset score to zero to match approved donor behavior', () => {
+    expect(calculateScoreTransition({
+      isCorrect: false,
+      currentScore: 1200,
+      clueValue: '$800',
+    })).toEqual({
+      isCorrect: false,
+      clueValue: 800,
+      previousScore: 1200,
+      newScore: 0,
+      scoreDelta: -1200,
     });
+  });
 
-    test('calculates incorrect round score with breakdown', () => {
-      const roundData = {
-        isCorrect: false,
-        baseValue: 200,
-        peekUsed: false
-      };
-      const result = ScoreCalculator.calculateRoundScore(roundData);
-      expect(result.total).toBe(-100);
-      expect(result.breakdown.base).toBe(0);
-      expect(result.breakdown.timeBonus).toBe(0);
-      expect(result.breakdown.streakBonus).toBe(0);
-      expect(result.breakdown.difficultyBonus).toBe(0);
-      expect(result.breakdown.penalty).toBe(-100);
+  test('timeouts are incorrect even when correctness input is true', () => {
+    expect(calculateScoreTransition({
+      isCorrect: true,
+      timedOut: true,
+      currentScore: 400,
+      clueValue: 200,
+    })).toMatchObject({
+      isCorrect: false,
+      newScore: 0,
+      scoreDelta: -400,
     });
+  });
 
-    test('calculates incorrect round score with peekUsed', () => {
-      const roundData = {
-        isCorrect: false,
-        baseValue: 200,
-        peekUsed: true
-      };
-      const result = ScoreCalculator.calculateRoundScore(roundData);
-      expect(result.total).toBe(-200);
-      expect(result.breakdown.penalty).toBe(-200);
-    });
+  test('score never becomes negative under the default contract', () => {
+    expect(calculateScoreTransition({
+      isCorrect: false,
+      currentScore: 0,
+      clueValue: 1000,
+    }).newScore).toBe(0);
+  });
 
-    test('calculates correct round score with peekUsed (total 0)', () => {
-      const roundData = {
-        isCorrect: true,
-        baseValue: 200,
-        timeElapsed: 3000,
-        streak: 5,
-        difficulty: 'hard',
-        peekUsed: true
-      };
-      const result = ScoreCalculator.calculateRoundScore(roundData);
-      expect(result.total).toBe(0);
-      expect(result.breakdown.base).toBe(0);
-      expect(result.breakdown.timeBonus).toBe(0);
-      expect(result.breakdown.streakBonus).toBe(0);
-      expect(result.breakdown.difficultyBonus).toBe(0); // Should be 0 when peekUsed
-      expect(result.breakdown.penalty).toBe(0);
-    });
+  test('supports a bounded subtract policy without changing the canonical default', () => {
+    expect(calculateScoreTransition({
+      isCorrect: false,
+      currentScore: 300,
+      clueValue: 400,
+      rules: {
+        ...SCORE_RULES,
+        incorrectScoreMode: 'subtract',
+      },
+    }).newScore).toBe(0);
   });
 });
-


### PR DESCRIPTION
## Why

Convergence #60 found two scoring doctrines and several non-domain responsibilities inside `GameEngine`. The production engine ignored authored clue values, a dead/tested scoring stack invented time/difficulty/streak bonuses and peek penalties, while approved Jeopardish parity fixtures used a much simpler clue-value contract.

## This slice

- replaces the dead scoring stack with one pure `calculateScoreTransition()` owner;
- parses authored numeric/display clue values;
- ports approved Main Game parity: correct adds clue value, incorrect/timeout resets current score to zero;
- leaves streak as separate state instead of secretly multiplying points;
- removes the 60 FPS game loop used to count down a trivia timer;
- uses one scheduled question timeout instead;
- removes duplicate question fetching from the engine because `main.js` already owns service orchestration;
- removes engine writes into a shadow store that never hydrated the engine back;
- makes achievement state serializable instead of storing a `Set` inside state;
- adds deterministic Main Game scoring/timing/boundary tests;
- retains a tiny transitional `getPerformanceStats()` compatibility shape only so the dev HUD does not break while performance polling is removed later.

## Explicit non-goals

- Head-to-Head scoring remains mode-owned.
- No Episode/Study/host/localization implementation here.
- No new bonus economy.
- No universal game engine extraction.

This is intended to leave fewer concepts a programmer must hold in their head to know what happens after an answer is submitted.