### PR TITLE
CI: move verification and Pages to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
+          package-manager-cache: false
 
       - name: Install
         run: npm ci
@@ -46,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Setup Java for Firestore emulator
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'
@@ -101,7 +102,7 @@ jobs:
 
       - name: Upload runtime evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runtime-check-evidence
           path: |
@@ -116,7 +117,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,10 +30,10 @@ jobs:
       VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.VITE_FIREBASE_STORAGE_BUCKET }}
       VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run needle-drop:validate
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   verify-live:
     name: verify-live-pages
@@ -180,10 +180,10 @@ jobs:
     if: needs.build.outputs.firebase_configured == 'true'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Install browser runtime dependency
@@ -198,7 +198,7 @@ jobs:
         run: node scripts/head-to-head-runtime-check.mjs
       - name: Upload cloud multiplayer evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: head-to-head-cloud-evidence
           path: screenshots/head-to-head-cloud

--- a/DEV_JOURNAL.d/2026-08-25T0557-node24-actions-modernization.md
+++ b/DEV_JOURNAL.d/2026-08-25T0557-node24-actions-modernization.md
@@ -1,0 +1,9 @@
+# 2026-08-25 05:57 ET — ChatGPT — Node 24 Actions modernization
+
+- **Read/inspected:** CI warning from the convergence PRs plus current official `actions/checkout`, `actions/setup-node`, `actions/setup-java`, `actions/upload-artifact`, Pages starter-workflow, and deploy-pages guidance.
+- **Changed:** CI now runs the application proof wall on Node 24 with `checkout@v7`, `setup-node@v7`, `setup-java@v6`, and `upload-artifact@v7`; Pages build/cloud-proof jobs now use Node 24 and current checkout/setup-node/upload-artifact generations; Pages deployment moves to `deploy-pages@v5`; deployment doctrine now requires Node 24 plus the current deploy-pages marker.
+- **Evidence/tests:** official action docs identify checkout/setup-node/upload-artifact v7 and setup-java v6 as current generations; setup-node documents Node 24 as the current baseline. Full repo CI must pass on this branch before merge; post-merge Pages exact-SHA verification remains the production proof.
+- **Decisions:** isolate runtime/action modernization from dependency upgrades; keep `configure-pages@v5` and the already-working `upload-pages-artifact@v4`; do not turn a deprecation cleanup into a tooling migration spree.
+- **Unresolved:** exact-head CI on Node 24; post-merge Pages deployment/exact-SHA proof; one fresh source-reachability pass to decide whether any remaining unreachable source is safely removable or intentionally dormant/reference material.
+- **Next lead domino:** prove/merge Node 24, then close the bounded convergence cleanup with docs/issue status and return to Firebase #44.
+- **Refs:** branch `chore/node24-actions-modernization`; base `main@e3617a0`; follows PR #64.

--- a/scripts/check-deployment-contract.mjs
+++ b/scripts/check-deployment-contract.mjs
@@ -43,7 +43,9 @@ if (!fs.existsSync(pagesWorkflowPath)) {
   const pagesWorkflow = fs.readFileSync(pagesWorkflowPath, 'utf8');
   const requiredMarkers = [
     'actions/upload-pages-artifact@v4',
-    'actions/deploy-pages@v4',
+    'actions/deploy-pages@v5',
+    'actions/setup-node@v7',
+    'node-version: 24',
     'verify-live-pages',
     'build-meta.json',
     'github.sha',
@@ -61,4 +63,4 @@ if (failed) {
   process.exit(1);
 }
 
-console.log('deployment-contract: GitHub Pages Actions is the only source-controlled publisher.');
+console.log('deployment-contract: GitHub Pages Actions is the only source-controlled publisher and runs on the Node 24 deployment baseline.');


### PR DESCRIPTION
## Why

The convergence PRs are green, but GitHub is explicitly warning that several pinned workflow actions still target deprecated Node 20 runtimes. This slice modernizes the proof/deploy machinery without mixing in application dependency upgrades.

## Changes

- CI application runtime: Node 20 → Node 24;
- `actions/checkout@v4` → `@v7`;
- `actions/setup-node@v4` → `@v7`;
- `actions/setup-java@v4` → `@v6`;
- `actions/upload-artifact@v4` → `@v7`;
- Pages build/cloud-proof runtime: Node 20 → Node 24;
- `actions/deploy-pages@v4` → `@v5`;
- deployment doctrine now requires the Node 24 Pages baseline and current deploy-pages marker.

`configure-pages@v5` and the already-proven `upload-pages-artifact@v4` stay unchanged.

## Evidence for versions

Current official action documentation identifies checkout/setup-node/upload-artifact v7 and setup-java v6 as current generations; setup-node documents Node 24 as the current baseline. The official Pages starter workflow also uses deploy-pages v5.

## Acceptance

The same blocking wall must pass under Node 24: critical audits, project doctrine/security, source reachability, JS/CSS lint, tests, build, Firestore rules, Main Game runtime, Needle Drop, Head-to-Head reconnect, accessibility, and artifacts.

After merge, the canonical Pages workflow remains responsible for proving the exact public git SHA and multiplayer transport.