### PR TITLE
Docs: close Convergence 2 and return lead domino to Firebase

### DIFF
--- a/DEV_JOURNAL.d/2026-08-25T0610-close-convergence-2.md
+++ b/DEV_JOURNAL.d/2026-08-25T0610-close-convergence-2.md
@@ -1,0 +1,9 @@
+# 2026-08-25 06:10 ET — ChatGPT — close Convergence 2.0
+
+- **Read/inspected:** issue #60 stop condition; issue #58 hygiene scope; exact PR #65 Node 24 CI/run logs; final source-reachability inventory; current master plan, docs router, canonical-doc registry and Convergence 2 capability matrix.
+- **Changed:** converted the Convergence 2 matrix from active work to a completed milestone; recorded PRs #61–#65 and the final 14-file dormant/hygiene inventory; rewrote the master plan around the now-proven baseline and restored Firebase #44 as the sole product lead domino; updated the docs router and machine registry to route the completed milestone.
+- **Evidence/tests:** PR #65 exact-head run `32834765144` passed 20 suites / 75 tests plus doctrine, reachability, lint, build, Firestore rules, Main Game, Needle Drop, H2H reconnect, accessibility and artifacts on Node 24. Reachability reported 50/62 source files reachable and 14 candidates, now classified rather than blindly deleted.
+- **Decisions:** Convergence 2.0 is complete when this docs closure is green/merged. Episode, Study/learning ledger, HostPack/HostPerformanceDirector, media preflight and localization remain focused follow-ups, not current blockers. Future archaeology stays in issue #58. Do not start another broad cleanup before Firebase proof absent a concrete blocker.
+- **Unresolved:** exact-head CI/merge for this docs-only closure; issue #60 should then close completed; issue #58 needs the final reachability update; Firebase #44 still requires production Firebase project/auth/config/rules/indexes/physical-device proof.
+- **Next lead domino:** issue #44, activate and automatically certify real Firebase Head-to-Head multiplayer.
+- **Refs:** branch `docs/close-convergence-2`; base `main@adc8834`; convergence PRs #61–#65.

--- a/docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md
+++ b/docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md
@@ -1,74 +1,97 @@
 # Convergence 2.0 Capability Matrix
 
-**Status:** ACTIVE RECONCILIATION REGISTER  
+**Status:** COMPLETED MILESTONE / REFERENCE REGISTER  
 **Date:** 2026-08-25  
-**Owner:** issue #60
+**Owner:** completed issue #60
 
-This register exists to prevent cleanup from deleting proven behavior or forgotten product intent. It is not permission to wholesale-merge `AlexBaldman/Jeopardish`, abandoned refactors, or speculative stacked systems.
+This register records what the bounded Convergence 2.0 campaign learned and deliberately does **not** authorize another broad cleanup pass. The campaign existed to recover proven Jeopardish behavior, remove duplicate domain truth, and preserve useful future capabilities without wholesale-merging `AlexBaldman/Jeopardish` or abandoned jeoPARODY architectures.
 
-The rule is:
+The rule that survived the work is:
 
 ```text
 prove behavior → port onto current ownership → add fixtures → retire donor/duplicate implementation
 ```
 
-## Dispositions
+## Shipped convergence
 
-- **PORT NOW** — duplicate truth or near-term architectural prerequisite; reconcile before Firebase work continues.
-- **FOCUSED FOLLOW-UP** — proven and valuable, but does not belong in the current truth-convergence slice.
-- **REFERENCE** — preserve design/behavior as donor material; do not port until a real consumer pulls it forward.
-- **RETIRE** — superseded or misleading implementation; preserve history only when provenance is useful.
+| Capability | Final disposition | Evidence / current owner |
+|---|---|---|
+| Answer judgment | **PORTED** | PR #61 / `c3f8a24`; `src/core/answerJudge.js` is shared by Main Game and Head-to-Head. |
+| Scoring / clue-value semantics | **PORTED** | PR #62 / `31e9a27`; `src/core/scoring.js` owns Main Game score transitions. Correct adds authored clue value; incorrect/timeout resets the current score. |
+| Main Game domain boundaries | **CONVERGED** | PR #62 removed the 60 FPS trivia timer, duplicate question fetching, shadow-store writes and performance state from `GameEngine`. |
+| Alternate game/controller/question/validator stack | **RETIRED** | PR #63 / `ac7b3ab`; 2,125 dead lines removed after useful behavior was reconciled. |
+| Shadow state + obsolete store-coupled host stack | **RETIRED** | PR #64 / `e3617a0`; 3,639 additional dead lines removed. Live host presentation remains `HostSystem` + `HostStageActor`. |
+| CI / deployment runtime | **MODERNIZED** | PR #65 / `adc8834`; blocking CI and Pages workflows run on Node 24/current GitHub Action generations. |
 
-## Current matrix
+The two retirement PRs alone removed roughly **5,764 lines** of duplicate architecture while the full browser/security/runtime wall stayed green.
 
-| Capability | Donor / evidence | Current jeoPARODY state | Disposition | Why |
-|---|---|---|---|---|
-| Answer judgment | `Jeopardish/game-logic.js` + donor tests | Main, H2H and old validators diverged | **PORT NOW** | Correctness is domain truth. Multiple judges can produce different winners. |
-| Scoring / clue-value / reveal semantics | donor game logic + current `GameEngine` + current `core/scoring.js` tests | Competing production and test-only doctrines | **PORT NOW** | Score is domain truth; dead tests must not guard a second ruleset. |
-| GameEngine responsibility boundaries | current `src/core/GameEngine.js` | Domain transitions mixed with fetching, persistence, achievements and FPS instrumentation | **PORT NOW** | Simplifies the path every future gameplay feature must understand. |
-| Authored Episode/content contract | August migration blueprint / Jeopardish episode work | Not yet a current canonical runtime owner | **FOCUSED FOLLOW-UP** | Strong next product/content primitive after truth convergence; should not block judge/scoring cleanup. |
-| Study pause/resume + learning ledger / review queue | proven Jeopardish Study behavior | Not represented as one current subsystem | **FOCUSED FOLLOW-UP** | Core educational promise; depends on stable clue identity + judgment/scoring events. |
-| HostPack / HostAvatarPack / HostPerformanceDirector | August blueprint / donor host work | Stage/show pieces exist, full contract not current | **FOCUSED FOLLOW-UP** | High product leverage, but presentation must stay downstream of stable truth. |
-| Media preflight / substitution / accessibility | donor media work + current runtime assets | Partial/current behavior distributed | **FOCUSED FOLLOW-UP** | Important release quality; reconcile after core rules and content contract. |
-| Bilingual / localization behavior | donor bilingual work | Not a current canonical runtime boundary | **FOCUSED FOLLOW-UP** | Valuable content-system requirement; should pressure-test Episode/content contract. |
-| Stage semantic presentation contracts | `docs/STAGE_RUNTIME_SYSTEM.md` + donor behavior | Current canonical Stage exists | **REFERENCE** | Preserve and extend through semantic events; do not re-import donor DOM architecture. |
-| Product-event / release proof | donor release gates + current CI/browser evidence | Current repo has stronger CI/runtime proof | **REFERENCE** | Mine missing assertions only; current pipeline owns release truth. |
-| Full Board | August blueprint / donor work | Not current lead path | **REFERENCE** | Later mode once domain/content contracts are stable. |
-| PAO / Memorization integration | current PAO surfaces + broader memory plan | Partial/experimental | **REFERENCE** | Preserve as later learning consumer; do not let it distort current trivia truth kernel. |
-| Couch Party | August blueprint | Not current lead path | **REFERENCE** | Valuable social mode after cloud multiplayer substrate is proven. |
-| Topic Shows / Host Studio / creator tooling | August blueprint | Not current runtime | **REFERENCE** | Product expansion after content + host contracts have stable owners. |
-| Stacked CharacterGenome / Stadium-style speculative systems | donor/speculative branches | Not current canonical requirement | **RETIRE / REFERENCE ONLY** | Do not drag speculative architecture into convergence merely because code exists. |
-| Legacy validator/comedy matcher helpers | current unreachable utility fossils | No production consumers found | **RETIRE AFTER JUDGE PORT** | Presentation/comedy does not belong in correctness truth; salvage copy only if independently valuable. |
+## Proven capabilities deliberately left for focused follow-up
 
-## Current convergence sequence
+These remain valuable. They did not need implementation to finish Convergence 2.0.
+
+| Capability | Disposition | Why it waits |
+|---|---|---|
+| Authored Episode/content contract | **FOCUSED FOLLOW-UP** | Strong content primitive after the current Firebase proof; should be rebuilt through current ownership rather than imported wholesale. |
+| Study pause/resume + learning ledger / review queue | **FOCUSED FOLLOW-UP** | Core educational promise; now has cleaner clue/judgment/scoring facts to build on. |
+| HostPack / HostAvatarPack / HostPerformanceDirector | **FOCUSED FOLLOW-UP** | High leverage, but presentation stays downstream of semantic game truth and the current `HostSystem`/Stage path. |
+| Media preflight / substitution / accessibility | **FOCUSED FOLLOW-UP** | Important release-quality capability; preserve donor behavior and current `MediaHandler` as reference until this becomes active work. |
+| Bilingual / localization behavior | **FOCUSED FOLLOW-UP** | Best used to pressure-test the future Episode/content contract. |
+| Stage semantic presentation contracts | **REFERENCE / EXTEND CURRENT OWNER** | `docs/STAGE_RUNTIME_SYSTEM.md` remains canonical; do not re-import donor DOM/state architecture. |
+| Product-event / release proof | **REFERENCE** | Current repo already has stronger blocking CI/runtime proof; mine donor assertions only when they add a missing guarantee. |
+| Full Board | **REFERENCE** | The current DOM surface is runtime-tested; the old `FullboardGameService` is not production truth. Revisit only when Full Board becomes active product work. |
+| PAO / Memorization integration | **REFERENCE** | Preserve as a later learning consumer without distorting current trivia-domain contracts. |
+| Couch Party | **REFERENCE** | Valuable after the cloud multiplayer substrate is proven. |
+| Topic Shows / Host Studio / creator tooling | **REFERENCE** | Product expansion after content + host contracts have stable owners. |
+| Stacked CharacterGenome / Stadium-style speculative systems | **RETIRE / REFERENCE ONLY** | Not a current requirement and not allowed to hitchhike into core architecture. |
+
+## Final source-reachability inventory
+
+The exact PR #65 Node 24 CI run (`32834765144`) reported **50/62 source files reachable from production entrypoints** and surfaced 14 candidates. Reachability is evidence, not a death sentence.
+
+### Intentional dormant / reference / tooling
+
+- `src/components/pao/CardPreview.js` — PAO/reference surface.
+- `src/dev/hud.js` and `src/dev/menu.js` — development tooling, intentionally outside production entrypoints.
+- `src/services/MediaHandler.js` — reference material for the focused media-preflight follow-up.
+- `src/services/ai.js`, `src/services/ai/PromptBuilder.js`, `src/services/ai/healthCheck.js`, `src/services/ai/localModelStub.js`, `src/services/ai/mockProvider.js` — legacy/tested AI experimentation family; not production authority and not a convergence blocker.
+
+### Later hygiene candidates, not current product blockers
+
+- `src/services/FullboardGameService.js` — old service beside the currently tested inline Full Board surface.
+- `src/services/api.js` — older generic API path beside the production question-service path.
+- `src/services/comedyTicker.js` — dormant presentation helper.
+- `src/services/storage.js` and `src/utils/helpers.js` — inspect together with any remaining dormant consumers before deleting.
+
+Issue #58 owns future repository archaeology. These files must not be treated as generic dead code merely because the import graph cannot reach them from a production entrypoint.
+
+## What Convergence 2.0 proved
 
 ```text
-1 canonical answer judge
-        ↓
-1 explicit scoring contract
-        ↓
-slim GameEngine boundaries
-        ↓
-retire displaced validators / matchers / dead owners
-        ↓
-re-run source reachability
-        ↓
-reconcile Episode + Study as focused follow-ups
-        ↓
-resume Firebase #44
+Main Game
+    ↓
+GameEngine
+    ├── answerJudge  ← shared correctness kernel → Head-to-Head
+    └── scoring      ← Main Game score transition
+    ↓
+semantic events
+    ↓
+HostSystem / Stage / UI
 ```
 
-## Stop condition
+Head-to-Head keeps its own match/authority/scoring state while sharing correctness behavior. This is deliberate mode ownership, not duplication.
 
-Convergence 2.0 is not an excuse to remodel the universe.
+## Stop condition: satisfied
 
-Stop the current bite when:
+1. Main Game and Head-to-Head share one answer-judgment kernel with donor-parity fixtures. **Done in #61.**
+2. Scoring has explicit ownership and no accidental test-only competing doctrine. **Done in #62.**
+3. `GameEngine` responsibilities are materially smaller and understandable. **Done in #62.**
+4. Displaced validators, alternate game owners, shadow state and obsolete host integrations were retired conservatively. **Done in #63–#64.**
+5. The source-reachability inventory was rerun and remaining candidates were classified rather than blindly deleted. **Done in #65 evidence.**
+6. Forgotten donor capabilities have explicit dispositions. **Recorded above.**
+7. Exact-head CI/browser/security evidence stayed green, including under Node 24. **Done through #65.**
 
-1. Main Game and Head-to-Head share one answer-judgment kernel with donor parity fixtures.
-2. Scoring has one explicit current owner or intentionally mode-specific owners with no accidental duplicate doctrine.
-3. `GameEngine` responsibilities are reduced to understandable game-domain orchestration, with externalities behind seams.
-4. The source-reachability inventory is rerun and displaced implementations are retired conservatively.
-5. Every major forgotten capability above has an explicit disposition.
-6. Exact-head CI/browser/security evidence is green.
+## Next product lead domino
 
-Then Firebase #44 resumes as the product lead domino.
+**Resume Firebase activation and real cloud proof in issue #44.**
+
+Do not start another convergence or repository-gardening campaign before that proof unless a concrete failure demonstrates that one of the remaining dormant files is actually blocking the product. The codebase has been sufficiently excavated. Humanity may return to building things.

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -2,262 +2,190 @@
 
 **Status:** CANONICAL ROUTING DOCUMENT  
 **Updated:** 2026-08-25  
-**Rule:** this file owns priorities and routing. Specialized architecture documents own their detailed domains.
+**Rule:** this file owns current priorities and routing. Specialized documents own their domains.
 
-JeoPARODY is the canonical proving ground for a larger family of playful learning, game-show, Stage, multiplayer, and eventually cross-world systems. The project should earn abstractions through working vertical slices rather than designing a universal engine in advance.
+JeoPARODY is the canonical proving ground for playful learning, game-show presentation, Stage systems, and multiplayer. Earn abstractions through working vertical slices. Do not design the universal engine in advance because software already has enough monuments to optimism.
 
 ## 1. Current proven baseline
 
-Head-to-Head multiplayer reached milestone commit `46d8f78` through PR #42. Documentation was re-routed through PR #43 (`a3b4c18`), the Pages workflow became Firebase-ready and exact-live-SHA self-verifying through PR #45 (`32b702c`), and the project-metabolism contract merged through PR #49 as `6443a8c`.
+The important upstream sequence is now:
 
-The repository now has blocking automated proof for:
+| Slice | Proof |
+|---|---|
+| Head-to-Head reconnect-safe foundation | PR #42 / `46d8f78` |
+| Documentation milestone + routing | PR #43 / `a3b4c18` |
+| Firebase-ready, exact-live-SHA Pages deployment | PR #45 / `32b702c` |
+| Self-checking docs/deployment doctrine | PR #49 / `6443a8c` |
+| Shared canonical answer judge | PR #61 / `c3f8a24` |
+| Explicit Main scoring + slim GameEngine | PR #62 / `31e9a27` |
+| Alternate game stack retired | PR #63 / `ac7b3ab` |
+| Shadow state + obsolete host stack retired | PR #64 / `e3617a0` |
+| Node 24 CI/Pages modernization | PR #65 / `adc8834` |
 
-- documentation/deployment doctrine via `npm run project:check`;
-- production Vite build;
-- unit/integration tests;
-- browser boot and deterministic main-game runtime;
-- Needle Drop runtime;
-- Head-to-Head two-tab create/join/ready/play/reveal flow;
-- host refresh after submitting and continued adjudication after reconnect;
-- challenger refresh after reveal;
-- converged clues, reveals, and scores across both clients;
-- Firestore Security Rules through the local emulator, including hostile-client cases;
-- accessibility audits and captured runtime evidence.
+The blocking proof wall covers project doctrine/security, source reachability, JS/CSS lint, unit/integration tests, production build, Firestore Security Rules, browser boot, Main Game runtime, Needle Drop runtime, Head-to-Head host/guest reconnect, accessibility audits, and captured runtime evidence.
 
-The canonical GitHub Pages publisher is now proven. `Deploy GitHub Pages` run `32754954244` deployed merge commit `6443a8cb9ef4c6db89aa02cf3b07badc00d0295e`; its live verification fetched the root, Needle Drop, Head-to-Head and `build-meta.json`, then proved the public `gitSha` exactly matched that commit. Issue #46 is complete.
+The canonical Pages publisher is GitHub Actions and has already been proven through exact-live-SHA verification. The deployment workflow stamps `build-meta.json`, verifies the public commit/transport, and conditionally runs independent-user Firebase cloud certification when Firebase configuration exists.
 
-**Current cloud boundary:** the same deployment run also proved that the production `VITE_FIREBASE_*` Actions variables are currently absent, so the live Head-to-Head build is intentionally using local proving mode. Real Firebase multiplayer is therefore the sole current lead domino.
+**Current cloud boundary:** the production `VITE_FIREBASE_*` repository variables were last proven absent, so the deployed Head-to-Head path remains intentionally in local proving mode until issue #44 activates Firebase.
 
-**Current security baseline:** dependency/security triage reduced the installed graph from roughly 742 packages / 32 advisories / 3 critical to 630 packages / 16 advisories / **0 critical** on the verified PR head. CI now blocks both production-only and full-graph critical advisories. AI provider service credentials are server-side-only doctrine, guarded by `npm run security:check`; Firebase web configuration remains intentionally client-visible.
+**Current security baseline:** production dependencies have zero known vulnerabilities under the blocking production audit; the full development graph has no critical advisories. Provider service credentials stay server-side. Firebase web configuration is intentionally client-visible configuration, not a secret.
 
-## 2. Project metabolism: completed upstream contract
+## 2. Convergence 2.0 is complete
 
-JeoPARODY now uses a small trusted control plane rather than asking every future human/agent to infer current truth from a large archive.
+Issue #60 was a bounded interruption before Firebase, not a new eternal phase of civilization.
+
+It delivered:
 
 ```text
-SMALL TRUSTED CONTROL PLANE
-README / AGENTS / docs router / master plan / architecture / journal
+ONE shared correctness kernel
         ↓
-machine-readable canonical owner registry
+explicit mode scoring ownership
         ↓
-blocking docs + deployment doctrine checks
+smaller Main Game domain owner
         ↓
-LARGE PRESERVED ARCHIVE
-milestones / audits / migration history / experiments / research
+retired alternate game + validator architecture
+        ↓
+retired shadow state + obsolete host architecture
+        ↓
+classified remaining dormant/reference source
+        ↓
+Node 24 proof wall
 ```
 
-Canonical documentation routing lives in `docs/README.md`; machine ownership is registered in `docs/canonical-docs.json`. Historical material remains searchable evidence but does not outrank registered current owners.
+PRs #63 and #64 alone removed roughly **5,764 lines** of duplicate architecture while the full proof wall remained green.
+
+The completed capability/disposition record is [`CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md`](CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md). Episode, Study/learning ledger, HostPack/HostPerformanceDirector, media preflight and localization remain valuable **focused follow-ups**, not blockers to the current product proof.
+
+Do not start another cleanup campaign merely because source reachability still reports intentionally dormant tooling/reference files. Issue #58 owns later repository archaeology.
 
 ## 3. One owner per truth
 
-This file must not become another encyclopedia. Route detailed questions to the document that owns them.
-
-| Domain | Canonical owner |
+| Domain | Owner |
 |---|---|
-| Repository entrypoint / current playable surfaces | `README.md` |
+| Repository entrypoint / playable surfaces | `README.md` |
 | Agent operating rules | `AGENTS.md` |
 | Documentation routing / roles | `docs/README.md` |
 | Current priorities / next lead domino | `docs/MASTER_PLAN.md` |
 | Runtime architecture / ownership boundaries | `ARCHITECTURE.md` |
-| Chronological engineering handoffs and evidence | `DEV_JOURNAL.md` |
-| Head-to-Head multiplayer architecture / security / deployment | `docs/HEAD_TO_HEAD_MULTIPLAYER_2026-08-24.md` |
-| Head-to-Head shipped milestone snapshot | `docs/MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md` |
-| Needle Drop gameplay architecture | `docs/NEEDLE_DROP_ARCHITECTURE.md` |
-| Stage runtime and projection boundary | `docs/STAGE_RUNTIME_SYSTEM.md` |
-| AI provider credentials / proxy boundary | `docs/AI_PROVIDER_SETUP.md` |
-| Historical canonical-repository convergence | `docs/JEOPARODY_CANONICAL_MIGRATION_STRATEGY_2026-08-08.md` |
-| Durable cross-project concept routing | `ICM/README.md` + `ICM/projects/*` |
+| Chronological engineering handoffs | `DEV_JOURNAL.md` |
+| Head-to-Head multiplayer | `docs/HEAD_TO_HEAD_MULTIPLAYER_2026-08-24.md` |
+| Needle Drop | `docs/NEEDLE_DROP_ARCHITECTURE.md` |
+| Stage / presentation boundary | `docs/STAGE_RUNTIME_SYSTEM.md` |
+| AI provider credential boundary | `docs/AI_PROVIDER_SETUP.md` |
+| Completed Convergence 2.0 record | `docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md` |
+| Cross-project concepts | `ICM/README.md` + `ICM/projects/*` |
 | Shared vocabulary | `docs/IMMORTAL_DEV_GLOSSARY.md` |
 
-When reality changes, update the smallest owner of that truth and leave a `DEV_JOURNAL.md` handoff. Do not spray the same mutable status across six documents.
+Links beat copies. When reality changes, update the smallest owner and leave a journal handoff.
 
-## 4. Lead-domino queue
+## 4. Current lead domino: Firebase #44
 
-### Domino 0 — activate and automatically certify real Firebase multiplayer
+**Activate and automatically certify real Firebase Head-to-Head multiplayer.** No more multiplayer features before this proof.
 
-Issue #44 owns the current product proof. Do this before adding more multiplayer features.
-
-Current evidence is explicit: the latest production Pages build reported these required repository Actions variables as missing:
+Required production web configuration:
 
 ```text
 VITE_FIREBASE_API_KEY
 VITE_FIREBASE_AUTH_DOMAIN
 VITE_FIREBASE_PROJECT_ID
 VITE_FIREBASE_APP_ID
+VITE_FIREBASE_STORAGE_BUCKET
+VITE_FIREBASE_MESSAGING_SENDER_ID
 ```
 
-`VITE_FIREBASE_STORAGE_BUCKET` and `VITE_FIREBASE_MESSAGING_SENDER_ID` are also supported when supplied by the selected Firebase web app.
+Execution order:
 
-Activation sequence:
-
-1. Select or create the production Firebase project.
-2. Enable Firebase Anonymous Auth.
-3. Add the Firebase web configuration as repository Actions variables.
-4. Deploy `firestore.rules` and `firestore.indexes.json`; confirm TTL field policies are accepted.
+1. Select/create the production Firebase project.
+2. Enable Firebase Anonymous Authentication.
+3. Add the web configuration as repository Actions variables.
+4. Deploy `firestore.rules` and `firestore.indexes.json`; confirm TTL policy acceptance.
 5. Trigger the canonical Pages deployment.
+6. Require the deployment to report `multiplayerTransport = firebase` and pass independent-user cloud runtime certification.
 
-The Pages workflow should not merely notice configuration. Once Firebase configuration is present, production deployment is expected to certify the cloud path automatically:
+The automated cloud proof uses isolated browser contexts so a silent fallback to `LocalRoomGateway` cannot counterfeit success.
 
-```text
-Firebase variables present
-        ↓
-Pages build stamps multiplayerTransport = firebase
-        ↓
-exact live SHA + transport metadata proof
-        ↓
-two isolated browser contexts
-        ↓
-independent Anonymous Auth users
-        ↓
-create / join / ready / same clue
-        ↓
-host submits + refreshes
-        ↓
-guest submits + reveal converges
-        ↓
-guest refreshes resolved round
-        ↓
-cloud evidence artifact
-```
-
-Using isolated contexts is deliberate. A silent fallback to `LocalRoomGateway` cannot pass because the two contexts do not share local browser storage.
+## 5. After automated Firebase proof
 
 ### Domino 1 — physical phone ↔ laptop proof
 
-Automated production cloud certification removes most deployment uncertainty, but it does not simulate mobile OS backgrounding, network changes, sleep, or actual device/browser behavior.
+Complete a five-clue match on two real devices. Refresh host after first submission, refresh challenger after reveal, background/foreground the phone, and interrupt networking briefly if practical. Measure actual reconnect pain before inventing presence/heartbeat infrastructure.
 
-After Domino 0 passes:
+### Domino 2 — promote Head-to-Head
 
-- host from one physical device;
-- challenger from another;
-- complete at least one five-clue match;
-- refresh the host after its first submission;
-- refresh the challenger after reveal;
-- background/foreground the phone;
-- briefly interrupt or switch networking if practical;
-- record any user-visible reconnect failure before inventing a heartbeat/presence subsystem.
+Add discoverable Main Menu entry/invite flow and explicit network recovery copy. Preserve guest-first entry. No mandatory account ceremony.
 
-### Domino 2 — promote Head-to-Head into the main experience
+### Domino 3 — earn the multiplayer kernel
 
-Only after real cloud + physical-device proof:
+Use a second real consumer, likely Needle Drop remote/multiplayer, before extracting shared multiplayer infrastructure. Extract only concepts proven across both consumers: identity, room/session, invite, command, public state/event, authority, reconnect, transport, lifecycle.
 
-- add the mode to the main menu / mode-select surface;
-- make room creation and invite sharing discoverable;
-- add explicit retry/recovery copy for network failures;
-- preserve guest-first entry with no account ceremony;
-- keep ranked/profile systems out of the critical path.
+### Domino 4 — trusted authority before stakes
 
-### Domino 3 — earn the reusable multiplayer kernel with a second consumer
+Move adjudication server-side before rankings, prizes, wagers or meaningful competitive ladders. Add latency-aware buzzer/input mechanics only when that product actually exists.
 
-Do not extract a grand universal multiplayer framework merely because one mode exists.
+## 6. Guardrails
 
-Use a second concrete consumer, likely a remote/controller or multiplayer slice for Needle Drop, to pressure-test the existing seams. Extract only the concepts that survive both modes:
+1. **Domain truth is deterministic.** UI and Stage render facts; they do not create them.
+2. **Correctness has one kernel.** Main Game and Head-to-Head share `answerJudge` behavior.
+3. **Scoring is explicitly mode-owned.** Shared correctness does not require one universal scoring system.
+4. **Transport is replaceable.** Firebase is an adapter, not the architecture.
+5. **Guest identity is enough until persistence creates user value.**
+6. **No premature presence system.** Observe real failures first.
+7. **No premature universal engine.** A second consumer earns extraction.
+8. **Private competitive answers remain private until reveal.**
+9. **Server authority precedes meaningful stakes.**
+10. **Infrastructure and doctrine stay source-controlled and CI-checked.**
+11. **Provider service credentials stay server-side.**
+12. **Production claims require production proof.** Build-time configuration alone does not count.
+13. **Preserve history without routing through it.**
+14. **Repository gardening has a stop condition.** A dormant file is not automatically product debt.
 
-```text
-Identity
-Room / Session
-Invite / Discovery
-Command
-Event / Public State
-Authority
-Reconnect
-Transport
-Lifecycle
-```
-
-The resulting abstraction should preserve swappable transports and allow authority to move server-side without rewriting game-domain logic.
-
-### Domino 4 — trusted authority before competitive stakes
-
-The current host-authoritative model is appropriate for casual proving play. Before public rankings, prizes, wagers, or meaningful competitive ladders:
-
-- move adjudication to a trusted server / Cloud Function / authoritative service;
-- retain the serializable command vocabulary where possible;
-- add latency-aware timing only when a real buzzer mechanic requires it;
-- calibrate phone/controller input through an earned input abstraction rather than coupling networking directly to game rules.
-
-## 5. Architectural guardrails
-
-1. **Game/domain truth stays deterministic.** UI and Stage render facts; they do not invent them.
-2. **Transport is replaceable.** Firebase is an implementation, not the game architecture.
-3. **Guest identity is enough until persistence creates value.** Do not build full login/password flows ahead of need.
-4. **Accounts are an upgrade path.** A completed guest session should later be claimable/linkable to a persistent profile.
-5. **No premature presence system.** Measure real disconnect pain first.
-6. **No premature universal engine.** A second consumer earns extraction.
-7. **Raw answers/private adjudication stay private until reveal.** Preserve the security boundary across transports.
-8. **Server authority precedes meaningful stakes.** Host authority is a proving seam, not a permanent anti-cheat strategy.
-9. **Source-controlled infrastructure.** Rules, indexes, lifecycle policy, tests, and deployment behavior belong in the repository.
-10. **Provider service credentials stay server-side.** Browser code may consume public Firebase web configuration, but Gemini/Claude-style bearer credentials never belong in source, URL parameters, client-visible Vite variables, or browser storage.
-11. **One owner per truth.** Prefer links to duplication.
-12. **Docs are executable doctrine.** Canonical ownership and deployment assumptions should fail CI when they drift.
-13. **Preserve history without routing through it.** A dated migration/audit document may remain accurate history without being current instructions.
-14. **Production claims require production proof.** Build-time Firebase configuration is not enough; a live cloud room must pass independent-user runtime certification.
-
-## 6. Definition of done for a substantive slice
-
-A feature is not finished because it works once on a developer machine.
-
-A substantive slice should normally leave behind:
+## 7. Definition of done for a substantive slice
 
 ```text
-IMPLEMENTATION
-+ project doctrine checks
-+ deterministic/unit proof
-+ blocking browser proof where relevant
-+ security/rules proof where relevant
-+ accessibility check
-+ runtime evidence
-+ canonical architecture/status update
+implementation
++ doctrine/security checks
++ deterministic tests
++ browser proof where relevant
++ rules/security proof where relevant
++ accessibility evidence
++ canonical owner update
 + DEV_JOURNAL handoff
 + focused branch / PR / commit history
-+ post-merge deployment verification when user-facing
++ post-merge deployment proof for user-facing changes
 ```
 
-Failures discovered by CI are product knowledge. Convert them into durable tests rather than merely fixing the symptom.
+Failures discovered by CI are product knowledge. Convert them into durable evidence rather than merely fixing the symptom.
 
-## 7. Current strategic shape
+## 8. Strategic shape
 
 ```text
-JeoPARODY domain/game modes
+Main / mode domain truth
         ↓
 semantic commands + events
         ↓
-Experience / Show Director
+Host / Show Director / Stage
         ↓
-Stage / projection
+presentation
 
 and, orthogonally:
 
-player identity
-        ↓
+identity
+  ↓
 room/session
-        ↓
+  ↓
 durable intent
-        ↓
+  ↓
 authority
-        ↓
-public deterministic truth
-        ↓
+  ↓
+public deterministic state
+  ↓
 multiple clients / projections
 ```
 
-These two axes should meet through explicit semantic boundaries, not through a giant manager object that knows everything and eventually demands its own parking space.
-
-## 8. Later, after the current dominos
-
-Candidates remain intentionally unordered until evidence promotes them:
-
-- optional “save my record” account-linking flow after meaningful play;
-- rematches, friends, match receipts, and persistent stats;
-- calibrated buzzer / phone input abstraction;
-- spectators and audience participation;
-- team play and tournaments;
-- richer Stage reactions driven by semantic match events;
-- cross-mode reusable multiplayer package;
-- broader uINVERSE pressure tests only after JeoPARODY earns the underlying contracts.
+These axes meet through explicit semantic boundaries, not a giant manager object that knows everything and eventually applies for municipal status.
 
 ## 9. Operating principle
 
-Build the smallest upstream capability that makes several downstream ideas easier, prove it in a real vertical slice, capture the lesson, then move to the next constraint.
+Build the smallest upstream capability that makes several downstream ideas easier, prove it in a real vertical slice, capture the lesson, then move to the next actual constraint.
 
-**Right now the only upstream product constraint is real Firebase activation and cloud proof.** Pages publishing and project metabolism are proven. Do not add another multiplayer feature until Firebase room creation, independent-user reconnect, and physical-device behavior have earned the next move.
+**The actual constraint is Firebase #44. Convergence 2.0 is closed. Resume product proof.**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 # JeoPARODY Documentation Router
 
-This directory is a **routing layer, not a second project database**. The goal is to make the current truth easy to find while preserving useful history without letting old documents silently become current architecture again.
+This directory is a **routing layer, not a second project database**. Make current truth easy to find while preserving history without letting old documents quietly become architecture again.
 
 ## The rule
 
 **One owner per truth. Links beat copies.**
 
-If a fact changes, update the smallest document that owns that fact and link to it from broader documents. Do not repeat mutable status in several plans, READMEs, handoffs, and audits.
+If a fact changes, update the smallest document that owns it and link to that owner from broader documents. Do not repeat mutable status across six plans because apparently Markdown can also develop distributed-consensus problems.
 
 ## Start here
 
@@ -18,51 +18,55 @@ If a fact changes, update the smallest document that owns that fact and link to 
 | Current priorities / next lead domino | [`MASTER_PLAN.md`](MASTER_PLAN.md) |
 | Chronological engineering handoff | [`../DEV_JOURNAL.md`](../DEV_JOURNAL.md) |
 | Durable cross-project concepts | [`../ICM/README.md`](../ICM/README.md) |
-| Shared project vocabulary | [`IMMORTAL_DEV_GLOSSARY.md`](IMMORTAL_DEV_GLOSSARY.md) |
+| Shared vocabulary | [`IMMORTAL_DEV_GLOSSARY.md`](IMMORTAL_DEV_GLOSSARY.md) |
 | Head-to-Head multiplayer | [`HEAD_TO_HEAD_MULTIPLAYER_2026-08-24.md`](HEAD_TO_HEAD_MULTIPLAYER_2026-08-24.md) |
 | Needle Drop | [`NEEDLE_DROP_ARCHITECTURE.md`](NEEDLE_DROP_ARCHITECTURE.md) |
 | Stage / show projection runtime | [`STAGE_RUNTIME_SYSTEM.md`](STAGE_RUNTIME_SYSTEM.md) |
 | AI-provider credentials and proxy boundary | [`AI_PROVIDER_SETUP.md`](AI_PROVIDER_SETUP.md) |
+| Completed Convergence 2.0 dispositions | [`CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md`](CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md) |
 | Canonical-repository migration history | [`JEOPARODY_CANONICAL_MIGRATION_STRATEGY_2026-08-08.md`](JEOPARODY_CANONICAL_MIGRATION_STRATEGY_2026-08-08.md) |
 
-The machine-readable version of this map is [`canonical-docs.json`](canonical-docs.json). `npm run docs:check` verifies that registered owners exist and that their local Markdown links resolve.
+The machine-readable version of this map is [`canonical-docs.json`](canonical-docs.json). `npm run docs:check` verifies registered owners/files and selected local links.
 
 ## Document roles
 
 ### CANONICAL
 
-Owns a current domain and may change as reality changes. There must be only one canonical owner for a domain.
+Owns a current mutable domain. There must be only one canonical owner for a domain.
 
-Examples: `MASTER_PLAN.md`, `ARCHITECTURE.md`, the Head-to-Head architecture document.
+Examples: `MASTER_PLAN.md`, `ARCHITECTURE.md`, Head-to-Head architecture.
 
 ### MILESTONE
 
-An immutable or mostly immutable snapshot of what was proven at a meaningful point in time. New reality should be recorded in a new milestone or the current canonical owner, not by rewriting history.
+A mostly immutable snapshot of a shipped proof or completed bounded campaign. New reality belongs in a current canonical owner or a new milestone, not by rewriting the old proof into something it was not.
 
-Example: [`MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md`](MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md).
+Examples:
+
+- [`MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md`](MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md)
+- [`CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md`](CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md)
 
 ### REFERENCE
 
-Useful specialized guidance, research, audits, implementation notes, or historical context. A reference document does **not** outrank a canonical owner when they disagree.
+Useful specialized guidance, research, audits, donor behavior, or historical implementation notes. Reference material does **not** outrank a canonical owner.
 
 ### HISTORY
 
-Preserved provenance. Historical material may contain superseded repository names, architecture, plans, or assumptions. Preserve it when useful, but do not route implementation agents through it as current truth.
+Preserved provenance. It may contain superseded repository names, architecture or plans. Preserve useful archaeology without routing current implementation through it.
 
 ## How to add documentation
 
 Before creating another Markdown file:
 
-1. Ask whether an existing canonical owner should simply be updated.
-2. If the new document owns a durable current domain, add it to `canonical-docs.json` with a unique domain.
-3. If it records a shipped proof or dated decision, make its milestone/reference status explicit.
-4. Link outward instead of duplicating current status.
+1. Ask whether an existing canonical owner should simply change.
+2. If the new document owns a durable current domain, register one unique domain in `canonical-docs.json`.
+3. If it records a completed proof/decision, mark it milestone/reference explicitly.
+4. Link instead of duplicating mutable status.
 5. Run `npm run docs:check`.
-6. For substantive work, leave a `DEV_JOURNAL.md` handoff.
+6. For substantive work, add a dated handoff under `DEV_JOURNAL.d/`.
 
 ## Cleanup doctrine
 
-Do **not** reorganize the whole docs tree merely because it looks untidy. Old audits and dated implementation notes can remain useful evidence. Cleanup should happen in this order:
+Do **not** reorganize the whole docs tree because it looks untidy. Cleanup order is:
 
 ```text
 identify current owner
@@ -71,15 +75,23 @@ repair contradictions
         ↓
 add routing / machine checks
         ↓
-understand inbound links + provenance
+understand provenance + inbound links
         ↓
-archive or retire obsolete documents deliberately
+archive or retire deliberately
+        ↓
+STOP when current work is no longer blocked
 ```
 
-A smaller number of trustworthy entrypoints is more valuable than a perfectly categorized graveyard.
+A small number of trustworthy entrypoints is more valuable than a perfectly alphabetized graveyard.
+
+## Current project boundary
+
+Convergence 2.0 is complete. Its milestone records the answer/scoring convergence, GameEngine simplification, retired duplicate architecture and disposition of remaining dormant/reference files.
+
+The product lead domino is again **Firebase activation and real cloud proof, issue #44**. Future repository hygiene belongs to issue #58 and must not preempt product work merely because an import graph contains unused candidates.
 
 ## Deployment truth
 
-The canonical static-site publisher is `.github/workflows/deploy-pages.yml` using GitHub Pages Actions. Do not add a second branch-based publisher or restore a `package.json` deploy script that writes to `gh-pages`.
+The canonical static-site publisher is `.github/workflows/deploy-pages.yml` using GitHub Pages Actions on the Node 24 workflow baseline. Do not add a second branch publisher or restore a `package.json` deploy script that writes to `gh-pages`.
 
-GitHub Pages Actions is now proven as the active publisher through an exact-live-SHA verification against the public site. Firebase cloud activation remains a separate concern tracked by issue #44; the deployment workflow records whether a release is using local or Firebase multiplayer transport and only runs cloud multiplayer certification when Firebase configuration is present.
+GitHub Pages Actions has been proven as the active publisher through exact-live-SHA verification. Firebase activation is separate: the workflow records whether a release uses local or Firebase multiplayer transport and only runs cloud multiplayer certification when Firebase configuration is present.

--- a/docs/canonical-docs.json
+++ b/docs/canonical-docs.json
@@ -28,7 +28,8 @@
     {
       "domain": "current-priorities",
       "path": "docs/MASTER_PLAN.md",
-      "role": "canonical"
+      "role": "canonical",
+      "checkLinks": true
     },
     {
       "domain": "engineering-handoffs",
@@ -83,6 +84,11 @@
     {
       "domain": "multiplayer-foundation-2026-08-24",
       "path": "docs/MULTIPLAYER_FOUNDATION_MILESTONE_2026-08-24.md",
+      "role": "milestone"
+    },
+    {
+      "domain": "convergence-2-2026-08-25",
+      "path": "docs/CONVERGENCE_2_CAPABILITY_MATRIX_2026-08-25.md",
       "role": "milestone"
     }
   ]


### PR DESCRIPTION
## Why

Issue #60 was intentionally bounded: remove duplicate truth, recover proven donor behavior, classify forgotten capabilities, prove the result, then stop gardening and return to Firebase #44. PRs #61–#65 have now satisfied the implementation/evidence side of that contract.

## This closure

- turns the Convergence 2 capability matrix into a completed milestone;
- records the shipped answer/scoring/GameEngine/dead-architecture/Node-24 convergence sequence;
- classifies the final 14 production-unreachable source candidates instead of treating them as automatic deletion targets;
- rewrites `docs/MASTER_PLAN.md` around the current proven baseline and restores Firebase #44 as the sole product lead domino;
- updates the docs router and machine registry so future agents route through the milestone rather than reopening it as active work;
- leaves a final handoff in `DEV_JOURNAL.d/`.

## Stop rule

Episode/Study/HostPack/media/localization remain explicitly valuable focused follow-ups. They are **not** blockers to Firebase and are not being implemented here.

Future repository archaeology remains in #58. A dormant file is not allowed to turn cleanup back into the product.

## Acceptance

Full existing doctrine/security/test/build/browser/multiplayer/accessibility evidence must remain green. After merge, close #60 completed and update #58 with the final reachability inventory.